### PR TITLE
Fix Duplicate Key Warning in Payment Requests View

### DIFF
--- a/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
+++ b/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
@@ -599,7 +599,7 @@ const CreatePaymentRequestPage = ({
             {/* Settings */}
             {/* Show only on desktop so we get the animation only on desktop */}
             {isReviewing && (
-              <div className="hidden md:block">
+              <div key="settings-desktop" className="hidden md:block">
                 <LayoutWrapper
                   key="settings"
                   animateOnExit={false}
@@ -611,8 +611,12 @@ const CreatePaymentRequestPage = ({
               </div>
             )}
 
-            {/* Show only on desktop so we DONt get the animation on mobile */}
-            {isReviewing && <div className="block md:hidden">{renderSettingsReview()}</div>}
+            {/* Show only on desktop so we DONT get the animation on mobile */}
+            {isReviewing && (
+              <div key="settings-mobile" className="block md:hidden">
+                {renderSettingsReview()}
+              </div>
+            )}
 
             {/* Buttons */}
             {currency &&


### PR DESCRIPTION
This pull request addresses a warning that was appearing in the console related to having multiple child components with the same key in the Payment Requests view. The issue has been resolved by ensuring unique keys for each child component. An image highlighting the original warning is attached to this PR for clarity.

![Duplicate Key Warning](https://github.com/nofrixion/nofrixion.business/assets/52673485/e64f99d2-199a-411f-9e93-7503d79fbf24)
