### PR TITLE
[MOOV-2125]: Reverted dynamic payment method defaults checkbox display logic

### DIFF
--- a/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
+++ b/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
@@ -702,9 +702,7 @@ const CreatePaymentRequestPage = ({
                           size="big"
                           onClick={onConfirmClicked}
                           disabled={isSubmitting}
-                          className={cn({
-                            '!bg-grey-text disabled:!opacity-100': isSubmitting,
-                          })}
+                          className="disabled:!opacity-100 disabled:!bg-grey-text"
                         >
                           {isSubmitting ? (
                             <Loader className="h-6 w-6 ml-0.5" />

--- a/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
+++ b/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
@@ -703,7 +703,7 @@ const CreatePaymentRequestPage = ({
                           onClick={onConfirmClicked}
                           disabled={isSubmitting}
                           className={cn({
-                            '!bg-greyText disabled:!opacity-100': isSubmitting,
+                            '!bg-grey-text disabled:!opacity-100': isSubmitting,
                           })}
                         >
                           {isSubmitting ? (

--- a/packages/components/src/components/ui/CustomModal/CustomModal.stories.tsx
+++ b/packages/components/src/components/ui/CustomModal/CustomModal.stories.tsx
@@ -26,6 +26,5 @@ export const Showcase = Template.bind({})
 Showcase.args = {
   title: 'I am a modal',
   open: true,
-  enableUseAsDefault: true,
   children: <div>I am the content of the modal</div>,
 }

--- a/packages/components/src/components/ui/CustomModal/CustomModal.tsx
+++ b/packages/components/src/components/ui/CustomModal/CustomModal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react'
-import { AnimatePresence, motion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { Fragment, useState } from 'react'
 
 import { cn } from '../../../utils'
@@ -8,7 +8,6 @@ import Checkbox from '../Checkbox/Checkbox'
 
 export interface CustomModalProps extends BaseModalProps {
   title: string
-  enableUseAsDefault?: boolean
   children: React.ReactNode
   onApplyEnabled?: boolean
   buttonRowClassName?: string
@@ -28,7 +27,6 @@ const CustomModal = ({
   title,
   children,
   open,
-  enableUseAsDefault,
   onApply,
   onDismiss,
   onApplyEnabled = true,
@@ -39,11 +37,6 @@ const CustomModal = ({
 
   const onApplyClicked = () => {
     if (!onApply) return
-
-    if (!enableUseAsDefault) {
-      onApply({})
-      return
-    }
 
     // Add the isDefaultChecked value to the formData
     const formData = {
@@ -126,21 +119,17 @@ const CustomModal = ({
                   )}
                 >
                   <div>
-                    <AnimatePresence>
-                      {enableUseAsDefault && (
-                        <motion.div
-                          initial={{ opacity: 0 }}
-                          animate={{ opacity: 1 }}
-                          exit={{ opacity: 0 }}
-                        >
-                          <Checkbox
-                            label="Use as my default"
-                            value={isDefaultChecked}
-                            onChange={setIsDefaultChecked}
-                          />
-                        </motion.div>
-                      )}
-                    </AnimatePresence>
+                    <motion.div
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                    >
+                      <Checkbox
+                        label="Use as my default"
+                        value={isDefaultChecked}
+                        onChange={setIsDefaultChecked}
+                      />
+                    </motion.div>
                   </div>
 
                   <Button

--- a/packages/components/src/components/ui/CustomModal/CustomModal.tsx
+++ b/packages/components/src/components/ui/CustomModal/CustomModal.tsx
@@ -1,5 +1,4 @@
 import { Dialog, Transition } from '@headlessui/react'
-import { motion } from 'framer-motion'
 import { Fragment, useState } from 'react'
 
 import { cn } from '../../../utils'
@@ -119,17 +118,11 @@ const CustomModal = ({
                   )}
                 >
                   <div>
-                    <motion.div
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      exit={{ opacity: 0 }}
-                    >
-                      <Checkbox
-                        label="Use as my default"
-                        value={isDefaultChecked}
-                        onChange={setIsDefaultChecked}
-                      />
-                    </motion.div>
+                    <Checkbox
+                      label="Use as my default"
+                      value={isDefaultChecked}
+                      onChange={setIsDefaultChecked}
+                    />
                   </div>
 
                   <Button

--- a/packages/components/src/components/ui/Modals/PaymentConditionsModal/PaymentConditionsModal.tsx
+++ b/packages/components/src/components/ui/Modals/PaymentConditionsModal/PaymentConditionsModal.tsx
@@ -50,7 +50,6 @@ const PaymentConditionsModal = ({
     <CustomModal
       title="Payment conditions"
       open={open}
-      enableUseAsDefault={true}
       onDismiss={handleOnDismiss}
       onApply={onApplyClicked}
     >

--- a/packages/components/src/components/ui/Modals/PaymentConditionsModal/PaymentConditionsModal.tsx
+++ b/packages/components/src/components/ui/Modals/PaymentConditionsModal/PaymentConditionsModal.tsx
@@ -1,5 +1,5 @@
 import { PaymentConditionsDefaults } from '@nofrixion/moneymoov'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { LocalPaymentConditionsFormValue } from '../../../../types/LocalTypes'
 import Checkbox from '../../Checkbox/Checkbox'
@@ -21,13 +21,6 @@ const PaymentConditionsModal = ({
     userDefaults ? userDefaults.allowPartialPayments : false,
   )
   const [currentState, setCurrentState] = useState<LocalPaymentConditionsFormValue>()
-  const [enableUseAsDefault, setEnableUseAsDefault] = useState<boolean>(false)
-
-  useEffect(() => {
-    setEnableUseAsDefault(
-      !userDefaults || userDefaults?.allowPartialPayments !== isAllowPartialEnabled,
-    )
-  }, [isAllowPartialEnabled])
 
   // When the user clicks on the Apply button, we need to send the data to the parent component
   const onApplyClicked = (data: any) => {
@@ -57,7 +50,7 @@ const PaymentConditionsModal = ({
     <CustomModal
       title="Payment conditions"
       open={open}
-      enableUseAsDefault={enableUseAsDefault}
+      enableUseAsDefault={true}
       onDismiss={handleOnDismiss}
       onApply={onApplyClicked}
     >

--- a/packages/components/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
+++ b/packages/components/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
@@ -184,7 +184,6 @@ const PaymentMethodsModal = ({
     <CustomModal
       title="Payment methods"
       open={open}
-      enableUseAsDefault={true}
       onDismiss={handleOnDismiss}
       onApply={onApplyClicked}
       onApplyEnabled={applyEnabled}

--- a/packages/components/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
+++ b/packages/components/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
@@ -49,7 +49,6 @@ const PaymentMethodsModal = ({
   const [isDefault, setIsDefault] = useState<boolean>(!isPrefilledData && !!userDefaults)
   const [priorityBank, setPriorityBank] = useState<BankSettings | undefined>()
   const [currentState, setCurrentState] = useState<LocalPaymentMethodsFormValue>()
-  const [enableUseAsDefault, setEnableUseAsDefault] = useState<boolean>(false)
   const [applyEnabled, setApplyEnabled] = useState<boolean>(true)
 
   /* Error alert states */
@@ -63,17 +62,6 @@ const PaymentMethodsModal = ({
   })
 
   useEffect(() => {
-    setEnableUseAsDefault(
-      !userDefaults ||
-        userDefaults?.pisp !== isBankEnabled ||
-        userDefaults?.card !== isCardEnabled ||
-        userDefaults?.wallet !== isWalletEnabled ||
-        userDefaults?.lightning !== isLightningEnabled ||
-        userDefaults?.cardAuthorizeOnly === isCaptureFundsEnabled ||
-        userDefaults?.pispPriorityBank !== isPriorityBankEnabled ||
-        (isPriorityBankEnabled && userDefaults?.pispPriorityBankID !== priorityBank?.bankID),
-    )
-
     setApplyEnabled(
       (isBankEnabled && (!amount || Number(amount) >= minimumCurrencyAmount)) ||
         (!isBankEnabled && (isWalletEnabled || isCardEnabled || isLightningEnabled)),
@@ -196,7 +184,7 @@ const PaymentMethodsModal = ({
     <CustomModal
       title="Payment methods"
       open={open}
-      enableUseAsDefault={enableUseAsDefault}
+      enableUseAsDefault={true}
       onDismiss={handleOnDismiss}
       onApply={onApplyClicked}
       onApplyEnabled={applyEnabled}

--- a/packages/components/src/components/ui/Modals/PaymentNotificationsModal/PaymentNotificationsModal.tsx
+++ b/packages/components/src/components/ui/Modals/PaymentNotificationsModal/PaymentNotificationsModal.tsx
@@ -1,6 +1,6 @@
 import { NotificationEmailsDefaults } from '@nofrixion/moneymoov'
 import { AnimatePresence } from 'framer-motion'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { LocalPaymentNotificationsFormValue } from '../../../../types/LocalTypes'
 import { validateEmail } from '../../../../utils/validation'
@@ -23,11 +23,6 @@ const PaymentNotificationsModal = ({
   const [email, setEmail] = useState(userDefaults ? userDefaults.emailAddresses : '')
   const [hasEmailError, setHasEmailError] = useState(false)
   const [currentState, setCurrentState] = useState<LocalPaymentNotificationsFormValue>()
-  const [enableUseAsDefault, setEnableUseAsDefault] = useState<boolean>(false)
-
-  useEffect(() => {
-    setEnableUseAsDefault(!userDefaults || (userDefaults?.emailAddresses ?? '') !== (email ?? ''))
-  }, [email])
 
   // When the user clicks on the Apply button, we need to send the data to the parent component
   const onApplyClicked = (data: any) => {
@@ -80,7 +75,7 @@ const PaymentNotificationsModal = ({
     <CustomModal
       title="Payment notifications"
       open={open}
-      enableUseAsDefault={enableUseAsDefault}
+      enableUseAsDefault={true}
       onDismiss={handleOnDismiss}
       onApply={onApplyClicked}
       onApplyEnabled={!hasEmailError}

--- a/packages/components/src/components/ui/Modals/PaymentNotificationsModal/PaymentNotificationsModal.tsx
+++ b/packages/components/src/components/ui/Modals/PaymentNotificationsModal/PaymentNotificationsModal.tsx
@@ -75,7 +75,6 @@ const PaymentNotificationsModal = ({
     <CustomModal
       title="Payment notifications"
       open={open}
-      enableUseAsDefault={true}
       onDismiss={handleOnDismiss}
       onApply={onApplyClicked}
       onApplyEnabled={!hasEmailError}


### PR DESCRIPTION
As discussed, the payment method defaults checkbox will always be shown to the user.

Also, fixed an issue with the gray background of the Create Payment Request button's disabled state.