### PR TITLE
Fix App Unusability Issue Post PR Creation and Correct CSS Class Naming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2569,9 +2569,12 @@
       "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
     },
     "node_modules/@headlessui/react": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.6.0.tgz",
-      "integrity": "sha512-PlDuytBC6iDC/uMvpANm5VpRSuayyXMEeo/dNIwAZNHCfhZUqDQgLXjGu48SHsvMw22Kc3c3u9TOAMZNg+1vzw==",
+      "version": "1.7.16",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.16.tgz",
+      "integrity": "sha512-2MphIAZdSUacZBT6EXk8AJkj+EuvaaJbtCyHTJrPsz8inhzCl7qeNPI1uk1AUvCgWylVtdN8cVVmnhUDPxPy3g==",
+      "dependencies": {
+        "client-only": "^0.0.1"
+      },
       "engines": {
         "node": ">=10"
       },
@@ -8375,6 +8378,11 @@
       "optionalDependencies": {
         "@colors/colors": "1.5.0"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -18794,7 +18802,7 @@
       "name": "@nofrixion/components",
       "version": "0.0.20",
       "dependencies": {
-        "@headlessui/react": "1.6.0",
+        "@headlessui/react": "^1.7.16",
         "@nofrixion/moneymoov": "*",
         "@radix-ui/react-checkbox": "^1.0.3",
         "@radix-ui/react-dialog": "^1.0.4",
@@ -19129,6 +19137,18 @@
         "vite-plugin-banner": "^0.7.0",
         "vite-plugin-css-injected-by-js": "^3.3.0",
         "vite-plugin-dts": "^2.3.0"
+      }
+    },
+    "packages/web-components/node_modules/@headlessui/react": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.6.0.tgz",
+      "integrity": "sha512-PlDuytBC6iDC/uMvpANm5VpRSuayyXMEeo/dNIwAZNHCfhZUqDQgLXjGu48SHsvMw22Kc3c3u9TOAMZNg+1vzw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "packages/web-components/node_modules/@ts-morph/common": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -15,7 +15,7 @@
     "prepare": "tw-patch install"
   },
   "dependencies": {
-    "@headlessui/react": "1.6.0",
+    "@headlessui/react": "^1.7.16",
     "@nofrixion/moneymoov": "*",
     "@radix-ui/react-checkbox": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.4",

--- a/packages/components/src/components/ui/CaptureModal/CaptureModal.tsx
+++ b/packages/components/src/components/ui/CaptureModal/CaptureModal.tsx
@@ -128,7 +128,7 @@ const CaptureModal: React.FC<CaptureModalProps> = ({
               className={cn(
                 'justify-center rounded-full bg-[#006A80] h-12 lg:h-11 px-16 text-sm text-white font-semibold transition w-full cursor-pointer hover:bg-[#144752]',
                 {
-                  '!bg-greyText disabled:!opacity-100 cursor-not-allowed': isCaptureButtonDisabled,
+                  '!bg-grey-text disabled:!opacity-100 cursor-not-allowed': isCaptureButtonDisabled,
                 },
               )}
               onClick={onCaptureClick}

--- a/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
+++ b/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
@@ -514,7 +514,7 @@ const CreatePaymentRequestPage = ({
             {/* Amount */}
             {currency && amount && (
               <LayoutWrapper key="amount" className={reviewRowClassNames}>
-                <span className="leading-6 text-greyText w-40 shrink-0">Amount</span>
+                <span className="leading-6 text-grey-text w-40 shrink-0">Amount</span>
                 <span
                   className={cn('font-semibold text-[2rem]/8 inline p-1', {
                     'bg-warning-yellow rounded':
@@ -703,7 +703,7 @@ const CreatePaymentRequestPage = ({
                           onClick={onConfirmClicked}
                           disabled={isSubmitting}
                           className={cn({
-                            '!bg-greyText disabled:!opacity-100': isSubmitting,
+                            '!bg-grey-text disabled:!opacity-100': isSubmitting,
                           })}
                         >
                           {isSubmitting ? (


### PR DESCRIPTION
This pull request addresses the following:

1. **App Unusability Post PR Creation**: There was a persisting issue where the app became unusable after creating a Payment Request and subsequently closing the details modal. This was due to the `@headlessui/react` library applying an `overflow: hidden` style directly to the HTML page without removing it afterward. To resolve this, the `@headlessui/react` was updated to its latest version. After this update, upon creating a total of 50 Payment Requests (28 on Chrome and 22 on Safari), the issue did not recur.
2. **CSS Class Correction**: Three instances were identified where CSS class names needed to be updated,`bg-greyText` was updated to `bg-grey-text`.