### PR TITLE
Integrate `AccountDashboard` Component into Current Accounts Page

### DIFF
--- a/apps/business/src/App.tsx
+++ b/apps/business/src/App.tsx
@@ -8,7 +8,7 @@ import { AuthProvider } from './lib/auth/AuthProvider'
 import { ProtectedRoutes } from './lib/auth/ProtectedRoutes'
 import AccountPayablePage from './pages/accounts-payable/page'
 import AccountReceivablePage from './pages/accounts-receivable/page'
-import AccountDashboardPage from './pages/current-accounts/[id]'
+import AccountDashboardPage from './pages/current-accounts/account-dashboard'
 import CurrentAccountsPage from './pages/current-accounts/page'
 import DashboardPage from './pages/dashboard/page'
 import Layout from './pages/layout'
@@ -31,7 +31,7 @@ export const App = () => {
                 <Route path="accounts-payable" element={<AccountPayablePage />} />
                 <Route path="accounts-receivable" element={<AccountReceivablePage />} />
                 <Route path="current-accounts" element={<CurrentAccountsPage />} />
-                <Route path="current-accounts/:id" element={<AccountDashboardPage />} />
+                <Route path="current-accounts/:accountId" element={<AccountDashboardPage />} />
                 <Route path="payouts" element={<PayoutsPage />} />
                 <Route path="users" element={<UsersPage />} />
                 <Route path="pricing" element={<PricingPage />} />

--- a/apps/business/src/App.tsx
+++ b/apps/business/src/App.tsx
@@ -8,6 +8,7 @@ import { AuthProvider } from './lib/auth/AuthProvider'
 import { ProtectedRoutes } from './lib/auth/ProtectedRoutes'
 import AccountPayablePage from './pages/accounts-payable/page'
 import AccountReceivablePage from './pages/accounts-receivable/page'
+import AccountDashboardPage from './pages/current-accounts/[id]'
 import CurrentAccountsPage from './pages/current-accounts/page'
 import DashboardPage from './pages/dashboard/page'
 import Layout from './pages/layout'
@@ -30,6 +31,7 @@ export const App = () => {
                 <Route path="accounts-payable" element={<AccountPayablePage />} />
                 <Route path="accounts-receivable" element={<AccountReceivablePage />} />
                 <Route path="current-accounts" element={<CurrentAccountsPage />} />
+                <Route path="current-accounts/:id" element={<AccountDashboardPage />} />
                 <Route path="payouts" element={<PayoutsPage />} />
                 <Route path="users" element={<UsersPage />} />
                 <Route path="pricing" element={<PricingPage />} />

--- a/apps/business/src/components/AccountPayableCard.tsx
+++ b/apps/business/src/components/AccountPayableCard.tsx
@@ -7,7 +7,13 @@ interface AccountPayableCardProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const AccountPayableCard: React.FC<AccountPayableCardProps> = ({ onShowViewAll, ...props }) => (
-  <Card title="Accounts payable" subtext="Coming soon" onShowViewAll={onShowViewAll} {...props}>
+  <Card
+    title="Accounts payable"
+    subtext="Coming soon"
+    onClick={onShowViewAll}
+    onShowViewAll={onShowViewAll}
+    {...props}
+  >
     <img
       src={WavesGraphic}
       alt="MoneyMoov for Business Graphic"

--- a/apps/business/src/components/AcountsReceivableCard.tsx
+++ b/apps/business/src/components/AcountsReceivableCard.tsx
@@ -52,7 +52,12 @@ const AcountsReceivableCard: React.FC<AcountsReceivableCardProps> = ({
   partiallyPaid,
   onShowViewAll,
 }) => (
-  <Card onShowViewAll={onShowViewAll} title="Accounts receivable" subtext="Last 30 days">
+  <Card
+    onClick={onShowViewAll}
+    onShowViewAll={onShowViewAll}
+    title="Accounts receivable"
+    subtext="Last 30 days"
+  >
     <div className="mt-16 w-full flex flex-col md:flex-row justify-between">
       <MetricInfo type="unpaid" value={unpaid} />
       <MetricInfo type="partiallyPaid" value={partiallyPaid} />

--- a/apps/business/src/components/ui/atoms/Card/Card.tsx
+++ b/apps/business/src/components/ui/atoms/Card/Card.tsx
@@ -22,7 +22,6 @@ const Card: React.FC<CardProps> = ({
         className,
       )}
       {...props}
-      onClick={onShowViewAll && onShowViewAll}
     >
       <div className="flex justify-between">
         {(title || subtext) && (

--- a/apps/business/src/components/ui/molecules/AccountsCarousel.tsx
+++ b/apps/business/src/components/ui/molecules/AccountsCarousel.tsx
@@ -95,7 +95,7 @@ const AccountsCarousel: React.FC<AccountsCarouselProps> = ({ accounts }) => {
                 account={account}
                 className="md:snap-center lg:snap-start" // Snap to center when scrolling (only for tablet resolution)
                 onClick={() => {
-                  navigate('current-accounts')
+                  navigate(`current-accounts/${account.id}`)
                 }}
               />
             )

--- a/apps/business/src/pages/current-accounts/[id].tsx
+++ b/apps/business/src/pages/current-accounts/[id].tsx
@@ -1,0 +1,27 @@
+import { AccountDashboard } from '@nofrixion/components'
+import { useNavigate, useParams } from 'react-router-dom'
+
+import { NOFRIXION_API_URL } from '../../lib/constants'
+
+const AccountDashboardPage = () => {
+  const navigate = useNavigate()
+  const { id } = useParams()
+
+  const onAllCurrentAccountsClick = () => {
+    navigate(`/home/current-accounts`)
+  }
+
+  return (
+    <div>
+      {id && (
+        <AccountDashboard
+          accountId={id}
+          apiUrl={NOFRIXION_API_URL}
+          onAllCurrentAccountsClick={onAllCurrentAccountsClick}
+        />
+      )}
+    </div>
+  )
+}
+
+export default AccountDashboardPage

--- a/apps/business/src/pages/current-accounts/account-dashboard.tsx
+++ b/apps/business/src/pages/current-accounts/account-dashboard.tsx
@@ -5,17 +5,17 @@ import { NOFRIXION_API_URL } from '../../lib/constants'
 
 const AccountDashboardPage = () => {
   const navigate = useNavigate()
-  const { id } = useParams()
+  const { accountId } = useParams()
 
   const onAllCurrentAccountsClick = () => {
-    navigate(`/home/current-accounts`)
+    navigate('../current-accounts')
   }
 
   return (
     <div>
-      {id && (
+      {accountId && (
         <AccountDashboard
-          accountId={id}
+          accountId={accountId}
           apiUrl={NOFRIXION_API_URL}
           onAllCurrentAccountsClick={onAllCurrentAccountsClick}
         />

--- a/apps/business/src/pages/current-accounts/page.tsx
+++ b/apps/business/src/pages/current-accounts/page.tsx
@@ -1,14 +1,31 @@
-import { Accounts } from '@nofrixion/components'
+import { AccountsList } from '@nofrixion/components'
+import { Account } from '@nofrixion/moneymoov'
+import { useNavigate } from 'react-router-dom'
 
 import { NOFRIXION_API_URL } from '../../lib/constants'
 import useMerchantStore from '../../lib/stores/useMerchantStore'
 import useStore from '../../lib/stores/useStore'
 
 const CurrentAccountsPage = () => {
-  // const { data: session, status, update } = useSession()
   const merchant = useStore(useMerchantStore, (state) => state.merchant)
+  const navigate = useNavigate()
 
-  return <div>{merchant && <Accounts merchantId={merchant.id} apiUrl={NOFRIXION_API_URL} />}</div>
+  const onAccountClick = (account: Account) => {
+    console.log(account)
+    navigate(`/home/current-accounts/${account.id}`)
+  }
+
+  return (
+    <div>
+      {merchant && (
+        <AccountsList
+          merchantId={merchant.id}
+          apiUrl={NOFRIXION_API_URL}
+          onAccountClick={onAccountClick}
+        />
+      )}
+    </div>
+  )
 }
 
 export default CurrentAccountsPage

--- a/apps/business/src/pages/current-accounts/page.tsx
+++ b/apps/business/src/pages/current-accounts/page.tsx
@@ -11,8 +11,7 @@ const CurrentAccountsPage = () => {
   const navigate = useNavigate()
 
   const onAccountClick = (account: Account) => {
-    console.log(account)
-    navigate(`/home/current-accounts/${account.id}`)
+    navigate(account.id)
   }
 
   return (

--- a/packages/clients/src/clients/AccountsClient.ts
+++ b/packages/clients/src/clients/AccountsClient.ts
@@ -1,5 +1,5 @@
 import { Account, ApiResponse, HttpMethod } from '../types'
-import { ApiProps, MerchantProps } from '../types/props'
+import { AccountProps, ApiProps, MerchantProps } from '../types/props'
 import { BaseApiClient } from './BaseApiClient'
 
 /**
@@ -18,6 +18,17 @@ export class AccountsClient extends BaseApiClient {
   constructor({ ...props }: ApiProps) {
     super(props.authToken)
     this.url = `${props.apiUrl}/accounts`
+  }
+
+  /**
+   * Gets a single account.
+   * @param accountId The account id to get.
+   * @returns All info of a specific account if successful. An ApiError if not successful.
+   */
+  async getAccount({ accountId }: AccountProps): Promise<ApiResponse<Account>> {
+    const response = await this.httpRequest<Account>(`${this.url}/${accountId}`, HttpMethod.GET)
+
+    return response
   }
 
   /**

--- a/packages/clients/src/hooks/index.ts
+++ b/packages/clients/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useAccount } from './useAccount'
 export { useAccounts } from './useAccounts'
 export { useAddTag } from './useAddTag'
 export { useBanks } from './useBanks'

--- a/packages/clients/src/hooks/useAccount.ts
+++ b/packages/clients/src/hooks/useAccount.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { AccountsClient } from '../clients'
+import { Account, ApiResponse } from '../types'
+import { AccountProps, ApiProps } from '../types/props'
+
+const fetchAccount = async (
+  apiUrl: string,
+  accountId?: string,
+  authToken?: string,
+): Promise<ApiResponse<Account>> => {
+  const client = new AccountsClient({ apiUrl, authToken })
+  const response = await client.getAccount({ accountId })
+
+  return response
+}
+
+export const useAccount = ({ accountId }: AccountProps, { apiUrl, authToken }: ApiProps) => {
+  const QUERY_KEY = ['Account', accountId, apiUrl, authToken]
+
+  return useQuery<ApiResponse<Account>, Error>(
+    QUERY_KEY,
+    () => fetchAccount(apiUrl, accountId, authToken),
+    {
+      enabled: !!accountId,
+    },
+  )
+}

--- a/packages/components/src/components/functional/AccountDashboard/AccountDashboard.stories.tsx
+++ b/packages/components/src/components/functional/AccountDashboard/AccountDashboard.stories.tsx
@@ -1,11 +1,11 @@
 import { Meta, StoryFn } from '@storybook/react'
 
 import { apiUrls } from '../../../utils/constants'
-import CurrentAccountTable from './CurrentAccountTable'
+import AccountDashboard from './AccountDashboard'
 
-const meta: Meta<typeof CurrentAccountTable> = {
+const meta: Meta<typeof AccountDashboard> = {
   title: 'Functional/Current Account Table',
-  component: CurrentAccountTable,
+  component: AccountDashboard,
   argTypes: {
     token: {
       control: {
@@ -17,9 +17,15 @@ const meta: Meta<typeof CurrentAccountTable> = {
       options: Object.values(apiUrls),
     },
   },
-} as Meta<typeof CurrentAccountTable>
+} as Meta<typeof AccountDashboard>
 
-const Template: StoryFn<typeof CurrentAccountTable> = (args) => <CurrentAccountTable {...args} />
+const Template: StoryFn<typeof AccountDashboard> = (args) => {
+  return (
+    <div className="px-14 py-10 bg-main-grey">
+      <AccountDashboard {...args} />
+    </div>
+  )
+}
 
 export const Showcase = Template.bind({})
 Showcase.args = {

--- a/packages/components/src/components/functional/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/functional/AccountDashboard/AccountDashboard.tsx
@@ -18,13 +18,19 @@ export interface AccountDashboardProps {
 const AccountDashboard = ({
   token,
   accountId,
+  onAllCurrentAccountsClick,
   apiUrl = 'https://api.nofrixion.com/api/v1',
 }: AccountDashboardProps) => {
   const queryClient = new QueryClient()
 
   return (
     <QueryClientProvider client={queryClient}>
-      <AccountDashboardMain token={token} accountId={accountId} apiUrl={apiUrl} />
+      <AccountDashboardMain
+        token={token}
+        accountId={accountId}
+        apiUrl={apiUrl}
+        onAllCurrentAccountsClick={onAllCurrentAccountsClick}
+      />
     </QueryClientProvider>
   )
 }

--- a/packages/components/src/components/functional/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/functional/AccountDashboard/AccountDashboard.tsx
@@ -1,37 +1,45 @@
 import { SortDirection, useTransactions } from '@nofrixion/moneymoov'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { add, endOfDay, startOfDay } from 'date-fns'
 import { useEffect, useState } from 'react'
 
 import { LocalTransaction } from '../../../types/LocalTypes'
 import { remoteTransactionsToLocal } from '../../../utils/parsers'
-import { TransactionsTable as UITransactionsTable } from '../../ui/organisms/TransactionsTable/TransactionsTable'
+import { DateRange } from '../../ui/DateRangePicker/DateRangePicker'
+import { AccountDashboard as UIAccountDashboard } from '../../ui/pages/AccountDashboard/AccountDashboard'
 
-export interface CurrentAccountTableProps {
+export interface AccountDashboardProps {
   token?: string // Example: "eyJhbGciOiJIUz..."
   accountId: string // Example: "bf9e1828-c6a1-4cc5-a012-08daf2ff1b2d"
   apiUrl: string // Example: "https://api.nofrixion.com/api/v1"
 }
 
-const CurrentAccountTable = ({
+const AccountDashboard = ({
   token,
   accountId,
   apiUrl = 'https://api.nofrixion.com/api/v1',
-}: CurrentAccountTableProps) => {
+}: AccountDashboardProps) => {
   const queryClient = new QueryClient()
 
   return (
     <QueryClientProvider client={queryClient}>
-      <CurrentAccountsTableMain token={token} accountId={accountId} apiUrl={apiUrl} />
+      <AccountDashboardMain token={token} accountId={accountId} apiUrl={apiUrl} />
     </QueryClientProvider>
   )
 }
 
 const pageSize = 10
 
-const CurrentAccountsTableMain = ({ token, accountId, apiUrl }: CurrentAccountTableProps) => {
+const AccountDashboardMain = ({ token, accountId, apiUrl }: AccountDashboardProps) => {
   const [page, setPage] = useState(1)
   const [totalRecords, setTotalRecords] = useState<number>(0)
   const [transactions, setTransactions] = useState<LocalTransaction[]>([])
+  const [dateRange, setDateRange] = useState<DateRange>({
+    fromDate: startOfDay(add(new Date(), { days: -90 })), // Last 90 days as default
+    toDate: endOfDay(new Date()),
+  })
+
+  const [searchFilter, setSearchFilter] = useState<string>('')
 
   const [transactionDateSortDirection, setTransactionDateDirection] = useState<SortDirection>(
     SortDirection.NONE,
@@ -45,6 +53,9 @@ const CurrentAccountsTableMain = ({ token, accountId, apiUrl }: CurrentAccountTa
       pageSize: pageSize,
       dateSortDirection: transactionDateSortDirection,
       amountSortDirection: amountSortDirection,
+      fromDateMS: dateRange.fromDate.getTime(),
+      toDateMS: dateRange.toDate.getTime(),
+      search: searchFilter,
     },
     { apiUrl: apiUrl, authToken: token },
   )
@@ -74,8 +85,12 @@ const CurrentAccountsTableMain = ({ token, accountId, apiUrl }: CurrentAccountTa
     }
   }
 
+  const onDateChange = (dateRange: DateRange) => {
+    setDateRange(dateRange)
+  }
+
   return (
-    <UITransactionsTable
+    <UIAccountDashboard
       transactions={transactions}
       pagination={{
         pageSize: pageSize,
@@ -83,8 +98,11 @@ const CurrentAccountsTableMain = ({ token, accountId, apiUrl }: CurrentAccountTa
       }}
       onPageChange={onPageChange}
       onSort={onSort}
+      onDateChange={onDateChange}
+      onSearch={setSearchFilter}
+      searchFilter={searchFilter}
     />
   )
 }
 
-export default CurrentAccountTable
+export default AccountDashboard

--- a/packages/components/src/components/functional/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/functional/AccountDashboard/AccountDashboard.tsx
@@ -1,4 +1,4 @@
-import { SortDirection, useTransactions } from '@nofrixion/moneymoov'
+import { SortDirection, useAccount, useTransactions } from '@nofrixion/moneymoov'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { add, endOfDay, startOfDay } from 'date-fns'
 import { useEffect, useState } from 'react'
@@ -10,6 +10,7 @@ import { AccountDashboard as UIAccountDashboard } from '../../ui/pages/AccountDa
 
 export interface AccountDashboardProps {
   token?: string // Example: "eyJhbGciOiJIUz..."
+  onAllCurrentAccountsClick?: () => void
   accountId: string // Example: "bf9e1828-c6a1-4cc5-a012-08daf2ff1b2d"
   apiUrl: string // Example: "https://api.nofrixion.com/api/v1"
 }
@@ -30,7 +31,12 @@ const AccountDashboard = ({
 
 const pageSize = 10
 
-const AccountDashboardMain = ({ token, accountId, apiUrl }: AccountDashboardProps) => {
+const AccountDashboardMain = ({
+  token,
+  accountId,
+  apiUrl,
+  onAllCurrentAccountsClick,
+}: AccountDashboardProps) => {
   const [page, setPage] = useState(1)
   const [totalRecords, setTotalRecords] = useState<number>(0)
   const [transactions, setTransactions] = useState<LocalTransaction[]>([])
@@ -56,6 +62,13 @@ const AccountDashboardMain = ({ token, accountId, apiUrl }: AccountDashboardProp
       fromDateMS: dateRange.fromDate.getTime(),
       toDateMS: dateRange.toDate.getTime(),
       search: searchFilter,
+    },
+    { apiUrl: apiUrl, authToken: token },
+  )
+
+  const { data: accountResponse } = useAccount(
+    {
+      accountId,
     },
     { apiUrl: apiUrl, authToken: token },
   )
@@ -92,6 +105,7 @@ const AccountDashboardMain = ({ token, accountId, apiUrl }: AccountDashboardProp
   return (
     <UIAccountDashboard
       transactions={transactions}
+      account={accountResponse?.status == 'success' ? accountResponse?.data : undefined}
       pagination={{
         pageSize: pageSize,
         totalSize: totalRecords,
@@ -101,6 +115,7 @@ const AccountDashboardMain = ({ token, accountId, apiUrl }: AccountDashboardProp
       onDateChange={onDateChange}
       onSearch={setSearchFilter}
       searchFilter={searchFilter}
+      onAllCurrentAccountsClick={onAllCurrentAccountsClick}
     />
   )
 }

--- a/packages/components/src/components/functional/CurrentAccountsList/CurrentAccountsList.stories.tsx
+++ b/packages/components/src/components/functional/CurrentAccountsList/CurrentAccountsList.stories.tsx
@@ -5,7 +5,7 @@ import { apiUrls } from '../../../utils/constants'
 import CurrentAcountsList from './CurrentAccountsList'
 
 const meta: Meta<typeof CurrentAcountsList> = {
-  title: 'Functional/Current Acounts',
+  title: 'Functional/Current Acounts List',
   component: CurrentAcountsList,
   argTypes: {
     token: {
@@ -31,7 +31,7 @@ export const Showcase = Template.bind({})
 Showcase.args = {
   token: 'eyJhbGciOiJIUz...',
   merchantId: 'bf9e1828-c6a1-4cc5-a012-...',
-  apiUrl: apiUrls.sandbox,
+  apiUrl: apiUrls.dev,
   onUnauthorized: action('onCreatePaymentAccount'),
 }
 

--- a/packages/components/src/components/functional/CurrentAccountsList/CurrentAccountsList.tsx
+++ b/packages/components/src/components/functional/CurrentAccountsList/CurrentAccountsList.tsx
@@ -1,4 +1,4 @@
-import { useAccounts } from '@nofrixion/moneymoov'
+import { Account, useAccounts } from '@nofrixion/moneymoov'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import CurrentAcountsList from '../../ui/Account/CurrentAccountsList/CurrentAcountsList'
@@ -8,6 +8,7 @@ export interface CurrentAccountsListProps {
   apiUrl?: string // Example: "https://api.nofrixion.com/api/v1"
   token?: string // Example: "eyJhbGciOiJIUz..."
   onUnauthorized?: () => void
+  onAccountClick?: (account: Account) => void
 }
 
 const queryClient = new QueryClient()
@@ -17,6 +18,7 @@ const CurrentAccountsList = ({
   apiUrl = 'https://api.nofrixion.com/api/v1',
   merchantId,
   onUnauthorized,
+  onAccountClick,
 }: CurrentAccountsListProps) => {
   return (
     <QueryClientProvider client={queryClient}>
@@ -25,6 +27,7 @@ const CurrentAccountsList = ({
         merchantId={merchantId}
         apiUrl={apiUrl}
         onUnauthorized={onUnauthorized}
+        onAccountClick={onAccountClick}
       />
     </QueryClientProvider>
   )
@@ -35,6 +38,7 @@ const CurrentAccountsMain = ({
   apiUrl = 'https://api.nofrixion.com/api/v1',
   merchantId,
   onUnauthorized,
+  onAccountClick,
 }: CurrentAccountsListProps) => {
   const { data: accounts } = useAccounts({ merchantId }, { apiUrl, authToken: token })
 
@@ -44,22 +48,10 @@ const CurrentAccountsMain = ({
     }
   }
 
-  const onCreatePaymentAccount = () => {
-    console.log('It works!')
-  }
-
-  const onAccountClick = () => {
-    console.log('Account click works')
-  }
-
   return (
     <>
       {accounts?.status === 'success' && accounts.data && (
-        <CurrentAcountsList
-          accounts={accounts.data}
-          onAccountClick={onAccountClick}
-          onCreatePaymentAccount={onCreatePaymentAccount}
-        />
+        <CurrentAcountsList accounts={accounts.data} onAccountClick={onAccountClick} />
       )}
     </>
   )

--- a/packages/components/src/components/ui/Account/AccountCard.tsx
+++ b/packages/components/src/components/ui/Account/AccountCard.tsx
@@ -1,23 +1,25 @@
 import { Account as AccountModel, AccountIdentifierType } from '@nofrixion/moneymoov'
 
+import { cn } from '../../../utils'
 import { DisplayAndCopy } from '../atoms'
 import AccountBalance from './AccountBalance/AccountBalance'
 
-export interface AccountCardProps {
+export interface AccountCardProps extends React.HTMLAttributes<HTMLButtonElement> {
   account: AccountModel
-  onAccountClick: () => void
 }
 
-const AccountCard: React.FC<AccountCardProps> = ({ account, onAccountClick }) => {
+const AccountCard: React.FC<AccountCardProps> = ({ account, className, ...props }) => {
   return (
-    <div className="flex flex-wrap sm:h-[124px] p-8 mb-6 bg-white gap-8 justify-between rounded-lg hover:shadow-[0px_2px_8px_0px_rgba(4,_41,_49,_0.1)]">
-      <div>
+    <button
+      {...props}
+      className={cn(
+        'flex flex-wrap sm:h-[124px] p-8 mb-6 bg-white gap-8 justify-between rounded-lg hover:shadow-[0px_2px_8px_0px_rgba(4,_41,_49,_0.1)] w-full',
+        className,
+      )}
+    >
+      <div className="text-left">
         <div className="mt-2">
-          <span
-            className="font-semibold text-xl leading-5"
-            onClick={() => onAccountClick()}
-            aria-hidden="true"
-          >
+          <span className="font-semibold text-xl leading-5" aria-hidden="true">
             {account.accountName}
           </span>
         </div>
@@ -39,7 +41,7 @@ const AccountCard: React.FC<AccountCardProps> = ({ account, onAccountClick }) =>
           availableBalance={account.availableBalance}
         />
       </div>
-    </div>
+    </button>
   )
 }
 

--- a/packages/components/src/components/ui/Account/CurrentAccountsHeader/CurrentAccountsHeader .tsx
+++ b/packages/components/src/components/ui/Account/CurrentAccountsHeader/CurrentAccountsHeader .tsx
@@ -1,7 +1,7 @@
 import { Button, Icon } from '../../atoms'
 
 export interface CurrentAccountsHeaderProps {
-  onCreatePaymentAccount: () => void
+  onCreatePaymentAccount?: () => void
 }
 
 const CurrentAccountsHeader = ({ onCreatePaymentAccount }: CurrentAccountsHeaderProps) => {
@@ -11,10 +11,12 @@ const CurrentAccountsHeader = ({ onCreatePaymentAccount }: CurrentAccountsHeader
         Currents accounts
       </span>
       <div className="w-[172px]">
-        <Button size="big" onClick={onCreatePaymentAccount} variant="secondary">
-          <Icon name="add/16" className="text-default-text" />
-          <span className="pl-2 md:inline-block">New Account</span>
-        </Button>
+        {onCreatePaymentAccount && (
+          <Button size="big" onClick={onCreatePaymentAccount} variant="secondary">
+            <Icon name="add/16" className="text-default-text" />
+            <span className="pl-2 md:inline-block">New Account</span>
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/packages/components/src/components/ui/Account/CurrentAccountsList/CurrentAcountsList.tsx
+++ b/packages/components/src/components/ui/Account/CurrentAccountsList/CurrentAcountsList.tsx
@@ -24,7 +24,7 @@ const CurrentAcountsList = ({
           {accounts
             .sort((a, b) => a.accountName?.localeCompare(b.accountName))
             .map((account, index) => (
-              <AccountCard key={index} account={account} onAccountClick={onAccountClick} />
+              <AccountCard key={index} account={account} onClick={onAccountClick} />
             ))}
         </div>
       )}

--- a/packages/components/src/components/ui/Account/CurrentAccountsList/CurrentAcountsList.tsx
+++ b/packages/components/src/components/ui/Account/CurrentAccountsList/CurrentAcountsList.tsx
@@ -1,4 +1,4 @@
-import { Account as AccountModel } from '@nofrixion/moneymoov'
+import { Account, Account as AccountModel } from '@nofrixion/moneymoov'
 
 import { Toaster } from '../../Toast/Toast'
 import AccountCard from '../AccountCard'
@@ -6,8 +6,8 @@ import CurrentAccountsHeader from '../CurrentAccountsHeader/CurrentAccountsHeade
 
 export interface CurrentAccountsListProps {
   accounts: AccountModel[] | undefined
-  onCreatePaymentAccount: () => void
-  onAccountClick: () => void
+  onCreatePaymentAccount?: () => void
+  onAccountClick?: (account: Account) => void
 }
 
 const CurrentAcountsList = ({
@@ -24,7 +24,13 @@ const CurrentAcountsList = ({
           {accounts
             .sort((a, b) => a.accountName?.localeCompare(b.accountName))
             .map((account, index) => (
-              <AccountCard key={index} account={account} onClick={onAccountClick} />
+              <AccountCard
+                key={index}
+                account={account}
+                onClick={() => {
+                  onAccountClick && onAccountClick(account)
+                }}
+              />
             ))}
         </div>
       )}

--- a/packages/components/src/components/ui/atoms/Button/Button.tsx
+++ b/packages/components/src/components/ui/atoms/Button/Button.tsx
@@ -1,10 +1,10 @@
 import { cva, VariantProps } from 'class-variance-authority'
 
 import { cn } from '../../../../utils'
-import { Icon } from '../Icon/Icon'
+import { Icon, IconNames } from '../Icon/Icon'
 
 const buttonVariants = cva(
-  'rounded-full inline-flex items-center justify-center whitespace-nowrap align-middle cursor-pointer transition w-full disabled:opacity-20 disabled:cursor-not-allowed',
+  'rounded-full inline-flex items-center justify-center whitespace-nowrap align-middle cursor-pointer transition w-full disabled:opacity-20 disabled:cursor-not-allowed select-none',
   {
     variants: {
       variant: {
@@ -17,7 +17,9 @@ const buttonVariants = cva(
           'hover:border-border-grey-highlighted',
           'text-default-text',
         ],
-        text: ['text-grey-text', 'hover:text-grey-text-hover'],
+        text: [
+          'text-grey-text underline underline-offset-2 hover:text-grey-text-hover hover:no-underline',
+        ],
       },
       size: {
         big: ['text-base', 'px-3', 'py-3', 'md:px-6', 'font-normal', 'leading-6'],
@@ -33,7 +35,7 @@ const buttonVariants = cva(
   },
 )
 
-const arrow = cva('w-full h-full', {
+const icon = cva('w-full h-full', {
   variants: {
     variant: {
       primary: ['text-white'],
@@ -48,7 +50,7 @@ const arrow = cva('w-full h-full', {
   },
 })
 
-const arrowContainer = cva('', {
+const iconContainer = cva('', {
   variants: {
     size: {
       big: ['w-4', 'h-4'],
@@ -67,12 +69,14 @@ export interface ButtonProps
     VariantProps<typeof buttonVariants> {
   previousArrow?: boolean
   nextArrow?: boolean
+  previousIcon?: IconNames
 }
 
 const Button: React.FC<ButtonProps> = ({
   variant,
   size,
   previousArrow,
+  previousIcon,
   nextArrow,
   className,
   children,
@@ -80,17 +84,23 @@ const Button: React.FC<ButtonProps> = ({
 }) => {
   return (
     <button className={cn(buttonVariants({ variant, size }), className)} {...props}>
-      {previousArrow && (
-        <div className={cn(arrowContainer({ size }), 'mr-2')}>
-          <Icon name="back/16" className={arrow({ variant })} />
+      {previousArrow && !previousIcon && (
+        <div className={cn(iconContainer({ size }), 'mr-2')}>
+          <Icon name="back/16" className={icon({ variant })} />
+        </div>
+      )}
+
+      {previousIcon && !previousArrow && (
+        <div className={cn(iconContainer({ size }), 'mr-2')}>
+          <Icon name={previousIcon} className={icon({ variant })} />
         </div>
       )}
 
       {children}
 
       {nextArrow && (
-        <div className={cn(arrowContainer({ size }), 'ml-2')}>
-          <Icon name="next/16" className={arrow({ variant })} />
+        <div className={cn(iconContainer({ size }), 'ml-2')}>
+          <Icon name="next/16" className={icon({ variant })} />
         </div>
       )}
     </button>

--- a/packages/components/src/components/ui/atoms/DisplayAndCopy/DisplayAndCopy.tsx
+++ b/packages/components/src/components/ui/atoms/DisplayAndCopy/DisplayAndCopy.tsx
@@ -8,7 +8,13 @@ export interface DisplayAndCopyProps extends React.HTMLAttributes<HTMLDivElement
 }
 
 const DisplayAndCopy: React.FC<DisplayAndCopyProps> = ({ name, value, className, ...props }) => {
-  const onCopy = (value: string, name: string) => {
+  const onCopy = (
+    e: React.MouseEvent<HTMLSpanElement, MouseEvent>,
+    value: string,
+    name: string,
+  ) => {
+    e.preventDefault()
+    e.stopPropagation()
     navigator.clipboard.writeText(value)
     makeToast('info', `${getNameOfValueCopied(name)} copied`)
   }
@@ -31,12 +37,12 @@ const DisplayAndCopy: React.FC<DisplayAndCopyProps> = ({ name, value, className,
       className={cn('flex leading-4 gap-2 text-[13px] font-normal items-center', className)}
       {...props}
     >
-      <span className="text-grey-text">{name}</span>
+      <span className="text-grey-text select-none">{name}</span>
       <span>{value}</span>
-      <span onClick={() => onCopy(value, name)} aria-hidden="true">
+      <span onClick={(e) => onCopy(e, value, name)} aria-hidden="true">
         <Icon
           name="copy/12px"
-          className="text-control-grey-hover cursor-pointer hover:text-border-grey-highlighted"
+          className="text-control-grey-hover cursor-pointer transition hover:text-border-grey-highlighted"
         />
       </span>
     </div>

--- a/packages/components/src/components/ui/atoms/Icon/Icon.tsx
+++ b/packages/components/src/components/ui/atoms/Icon/Icon.tsx
@@ -193,7 +193,12 @@ export const Icons = {
       />
     </SVG>
   ),
-
+  'back/12': (className: string) => (
+    <SVG className={className} size="12">
+      <path d="M6 11L0.999999 6L6 1" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M1 6L11 6" strokeLinecap="round" strokeLinejoin="round" />
+    </SVG>
+  ),
   'done/12': (className: string) => (
     <SVG className={className} size="12">
       <path d="M1.5 6.31579L4.34211 9.15789L10.5 3" strokeLinecap="round" strokeLinejoin="round" />
@@ -273,6 +278,17 @@ export const Icons = {
           <rect width="12" height="12" fill="white" />
         </clipPath>
       </defs>
+    </SVG>
+  ),
+  'download/12': (className: string) => (
+    <SVG className={className} size="12">
+      <path d="M6 9L6 1" strokeLinecap="round" strokeLinejoin="round" />
+      <path
+        d="M4.125 7.49902L6 9.37402L7.875 7.49902"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M1 11H11" strokeLinecap="round" strokeLinejoin="round" />
     </SVG>
   ),
   'arrow-down/8': (className: string) => (

--- a/packages/components/src/components/ui/organisms/TransactionsTable/TransactionsTable.tsx
+++ b/packages/components/src/components/ui/organisms/TransactionsTable/TransactionsTable.tsx
@@ -130,7 +130,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
             </TableBody>
           </Table>
 
-          <div className="flex items-center justify-end py-4">
+          <div className="flex items-center justify-end mt-8">
             <Pager
               onPageChange={onPageChange}
               pageSize={pagination.pageSize}

--- a/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.stories.tsx
+++ b/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from '@storybook/addon-actions'
 import { Meta, StoryFn } from '@storybook/react'
 
-import { mockedTransactions } from '../../../../utils/mockedData'
+import { mockAccounts, mockedTransactions } from '../../../../utils/mockedData'
 import { AccountDashboard } from './AccountDashboard'
 
 export default {
@@ -26,6 +26,7 @@ const Template: StoryFn<typeof AccountDashboard> = (args) => {
 export const Showcase = Template.bind({})
 Showcase.args = {
   transactions: mockedTransactions,
+  account: mockAccounts[0],
   pagination: {
     pageSize: 10,
     totalSize: 100,

--- a/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.stories.tsx
+++ b/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.stories.tsx
@@ -1,0 +1,33 @@
+import { action } from '@storybook/addon-actions'
+import { Meta, StoryFn } from '@storybook/react'
+
+import { mockedTransactions } from '../../../../utils/mockedData'
+import { AccountDashboard } from './AccountDashboard'
+
+export default {
+  title: 'Pages/Account Dashboard',
+  component: AccountDashboard,
+  args: {
+    onSearch: action('onSearch'),
+    onDateChange: action('onDateChange'),
+    onPageChange: action('onPageChange'),
+    onSort: action('onSort'),
+  },
+} as Meta<typeof AccountDashboard>
+
+const Template: StoryFn<typeof AccountDashboard> = (args) => {
+  return (
+    <div className="px-14 py-10 bg-main-grey">
+      <AccountDashboard {...args} />
+    </div>
+  )
+}
+
+export const Showcase = Template.bind({})
+Showcase.args = {
+  transactions: mockedTransactions,
+  pagination: {
+    pageSize: 10,
+    totalSize: 100,
+  },
+}

--- a/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
@@ -1,0 +1,89 @@
+import { Pagination, SortDirection } from '@nofrixion/moneymoov'
+import * as React from 'react'
+
+import { LocalTransaction } from '../../../../types/LocalTypes'
+import { Icon } from '../../atoms'
+import DateRangePicker, { DateRange } from '../../DateRangePicker/DateRangePicker'
+import { TransactionsTable } from '../../organisms/TransactionsTable/TransactionsTable'
+import SearchBar from '../../SearchBar/SearchBar'
+
+export interface AccountDashboardProps extends React.HTMLAttributes<HTMLDivElement> {
+  transactions: LocalTransaction[]
+  pagination: Pick<Pagination, 'pageSize' | 'totalSize'>
+  searchFilter: string
+  onPageChange: (page: number) => void
+  onSort: (name: 'date' | 'amount', direction: SortDirection) => void
+  onDateChange: (dateRange: DateRange) => void
+  onSearch: (searchFilter: string) => void
+}
+
+const AccountDashboard: React.FC<AccountDashboardProps> = ({
+  transactions,
+  pagination,
+  searchFilter,
+  onDateChange,
+  onSearch,
+  onPageChange,
+  onSort,
+}) => {
+  return (
+    <>
+      <div className="mb-12">
+        <div className="flex justify-between">
+          <button onClick={() => {}} className="flex items-center space-x-3">
+            <Icon name="back/12" />
+            <span>All current accounts</span>
+          </button>
+          {/* TODO: Implement download statement feature*/}
+          {/* <div>
+            <Button
+              variant="text"
+              size="small"
+              previousIcon="download/12"
+              className="text-default-text"
+              onClick={() => {}}
+            >
+              Download statement
+            </Button>
+          </div> */}
+        </div>
+
+        {/*  TODO: Use account info from hook */}
+        <div className="flex justify-between mt-6">
+          <div className="text-[28px]/8 font-semibold">
+            <h2>Main account Euros</h2>
+            {/* TODO: Use Display and copy component (Arif's component) */}
+          </div>
+
+          <div className="flex flex-col items-end">
+            {/* TODO: Use Arif's component instead*/}
+            <h2 className="text-[32px]/9 font-semibold">€ 34,197.00</h2>
+            <span className="text-sm/5">Available € 32,845.00</span>
+
+            {/* TODO: Add expand component */}
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-[10px] h-16 flex justify-between items-center px-3 mb-4">
+        <DateRangePicker onDateChange={onDateChange} />
+
+        <SearchBar value={searchFilter} setValue={onSearch} />
+      </div>
+
+      <div className="bg-white rounded-lg px-7 py-8">
+        <TransactionsTable
+          transactions={transactions}
+          pagination={{
+            pageSize: pagination.pageSize,
+            totalSize: pagination.totalSize,
+          }}
+          onPageChange={onPageChange}
+          onSort={onSort}
+        />
+      </div>
+    </>
+  )
+}
+
+export { AccountDashboard }

--- a/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
@@ -13,6 +13,7 @@ import { DisplayAndCopy, Icon } from '../../atoms'
 import DateRangePicker, { DateRange } from '../../DateRangePicker/DateRangePicker'
 import { TransactionsTable } from '../../organisms/TransactionsTable/TransactionsTable'
 import SearchBar from '../../SearchBar/SearchBar'
+import { Toaster } from '../../Toast/Toast'
 
 export interface AccountDashboardProps extends React.HTMLAttributes<HTMLDivElement> {
   transactions: LocalTransaction[]
@@ -107,6 +108,8 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
           onSort={onSort}
         />
       </div>
+
+      <Toaster positionY="top" positionX="right" duration={3000} />
     </>
   )
 }

--- a/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
@@ -1,36 +1,47 @@
-import { Pagination, SortDirection } from '@nofrixion/moneymoov'
+import {
+  Account,
+  AccountIdentifierType,
+  Currency,
+  Pagination,
+  SortDirection,
+} from '@nofrixion/moneymoov'
 import * as React from 'react'
 
 import { LocalTransaction } from '../../../../types/LocalTypes'
-import { Icon } from '../../atoms'
+import AccountBalance from '../../Account/AccountBalance/AccountBalance'
+import { DisplayAndCopy, Icon } from '../../atoms'
 import DateRangePicker, { DateRange } from '../../DateRangePicker/DateRangePicker'
 import { TransactionsTable } from '../../organisms/TransactionsTable/TransactionsTable'
 import SearchBar from '../../SearchBar/SearchBar'
 
 export interface AccountDashboardProps extends React.HTMLAttributes<HTMLDivElement> {
   transactions: LocalTransaction[]
+  account?: Account
   pagination: Pick<Pagination, 'pageSize' | 'totalSize'>
   searchFilter: string
   onPageChange: (page: number) => void
   onSort: (name: 'date' | 'amount', direction: SortDirection) => void
   onDateChange: (dateRange: DateRange) => void
   onSearch: (searchFilter: string) => void
+  onAllCurrentAccountsClick?: () => void
 }
 
 const AccountDashboard: React.FC<AccountDashboardProps> = ({
   transactions,
+  account,
   pagination,
   searchFilter,
   onDateChange,
   onSearch,
   onPageChange,
   onSort,
+  onAllCurrentAccountsClick,
 }) => {
   return (
     <>
       <div className="mb-12">
         <div className="flex justify-between">
-          <button onClick={() => {}} className="flex items-center space-x-3">
+          <button onClick={onAllCurrentAccountsClick} className="flex items-center space-x-3">
             <Icon name="back/12" />
             <span>All current accounts</span>
           </button>
@@ -51,14 +62,28 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
         {/*  TODO: Use account info from hook */}
         <div className="flex justify-between mt-6">
           <div className="text-[28px]/8 font-semibold">
-            <h2>Main account Euros</h2>
-            {/* TODO: Use Display and copy component (Arif's component) */}
+            <h2>{account?.accountName}</h2>
+            <div className="flex gap-6 mt-2">
+              {account?.identifier.type === AccountIdentifierType.IBAN ? (
+                <DisplayAndCopy name="IBAN" value={account.identifier.iban} />
+              ) : account?.identifier.type === AccountIdentifierType.SCAN ? (
+                <>
+                  <DisplayAndCopy name="SC" value={account?.identifier.sortCode} />
+                  <DisplayAndCopy name="AN" value={account?.identifier.accountNumber} />
+                </>
+              ) : (
+                <></>
+              )}
+            </div>
           </div>
 
           <div className="flex flex-col items-end">
             {/* TODO: Use Arif's component instead*/}
-            <h2 className="text-[32px]/9 font-semibold">€ 34,197.00</h2>
-            <span className="text-sm/5">Available € 32,845.00</span>
+            <AccountBalance
+              availableBalance={account?.availableBalance ?? 0}
+              balance={account?.balance ?? 0}
+              currency={account?.currency ?? Currency.None}
+            />
 
             {/* TODO: Add expand component */}
           </div>

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,8 +1,5 @@
 import './index.css' // Import Tailwind CSS
 
-// Web Components that want to be built
-// need to be imported here
-// import './web-components/PaymentRequestDashboard/WebPaymentRequestDashboard';
-
-export { default as Accounts } from './components/functional/CurrentAccountsList/CurrentAccountsList'
+export { default as AccountDashboard } from './components/functional/AccountDashboard/AccountDashboard'
+export { default as AccountsList } from './components/functional/CurrentAccountsList/CurrentAccountsList'
 export { default as AccountsReceivable } from './components/functional/PaymentRequestDashboard/PaymentRequestDashboard'

--- a/packages/components/src/utils/mockedData.ts
+++ b/packages/components/src/utils/mockedData.ts
@@ -993,7 +993,7 @@ export const mockedTransactions: LocalTransaction[] = [
     balanceAfterTx: 32345,
     reference: 'Dinner Payment',
     description: 'Lorem Ipsum er ganske enkelt fyldtekst fra print- og typografiindustrien.',
-    type: 'undefined',
+    type: '',
   },
 ]
 


### PR DESCRIPTION
This pull request encompasses several updates related to the AccountDashboard:

- Introduced the `AccountDashboard` UI component.
- Developed the `AccountDashboard` functional component.
- Integrated the `AccountDashboard` functional component into the existing Current Accounts page in Business. With this update, users can click on any account from the Current Account Lists to dive deeper into its balance details and view all associated transactions.

Please be aware of the following considerations:

1. Pablo I. has not been included in this review. The intent is to have this primarily as a dev review. Post-merging this PR, I'll be talking with Pablo I. for a review in Business Dev, ensuring he can access it without any additional setup.
2. There are some missing UI details, such as skeleton loaders. This omission might cause a few UI elements to appear abruptly post-loading. Apart from this loading-to-loaded transition, the user interface should be functioning optimally.
3. The feature for collapsible pending transactions hasn't been added within this PR. @arifmatin is currently developing that component.

Your feedback will be greatly appreciated.