### PR TITLE
Eenhance PRs logout behavior

### DIFF
--- a/apps/business/src/lib/auth/userAuth.tsx
+++ b/apps/business/src/lib/auth/userAuth.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { NOFRIXION_BFF_URL } from '../constants'
+import { getRoute } from '../utils/utils'
 
 const config = {
   headers: {
@@ -62,7 +63,8 @@ const useAuthUser = () => {
 
   const logOut = useCallback(
     (callback?: string) => {
-      const url = `${logoutUrl}&returnUrl=/?callbackUrl=${callback ?? '/'}`
+      const returnUrl = getRoute('/')
+      const url = `${logoutUrl}&returnUrl=${returnUrl}?callbackUrl=${callback ?? '/'}`
 
       setIsLoggedIn(false)
       window.location.href = url ?? '/'


### PR DESCRIPTION
Modifications made:

- Initially, adjustments were made to utilise the `/pr/{number}` URL structure over the direct `/{prNumber}` format. However, after observing that #35 already addressed the issues those changes aimed to solve, those modifications were reverted.
- Enhanced the logout functionality: Now, when a user logs out, the system redirects back to the URL containing the PR number. This ensures that users are consistently brought back to the version of the Portal associated with the Pull Request.