### PR TITLE
Fix Account Card Arrows (in carousel)

### DIFF
--- a/apps/business/src/components/ui/ScrollArea.tsx
+++ b/apps/business/src/components/ui/ScrollArea.tsx
@@ -17,8 +17,6 @@ const ScrollArea = forwardRef<
     </RadixScrollArea.Viewport>
     <RadixScrollArea.Scrollbar
       forceMount
-      // forceMount={enableCustomScrollbar}
-      // flex-col
       className={cn(
         'flex select-none overflow-hidden touch-none rounded-lg bg-gray-100 transition-colors duration-[160ms] ease-out hover:bg-gray-200 flex-col h-2',
         {

--- a/apps/business/src/components/ui/molecules/AccountsCarousel.tsx
+++ b/apps/business/src/components/ui/molecules/AccountsCarousel.tsx
@@ -72,7 +72,7 @@ const AccountsCarousel: React.FC<AccountsCarouselProps> = ({ accounts }) => {
         {scrollState !== 'left' && scrollState !== 'not-needed' && (
           <button
             onClick={scrollLeft}
-            className="hidden lg:flex absolute top-0 -left-0.5 h-full w-[104px] bg-gradient-to-l from-transparent to-main-grey items-center justify-start pl-4"
+            className="hidden lg:flex absolute top-0 left-0 h-full w-[104px] bg-gradient-to-l from-transparent to-main-grey items-center justify-start pl-4"
           >
             <div className="w-12 h-8 bg-white rounded-full flex justify-center items-center shadow-small">
               <svg
@@ -114,7 +114,7 @@ const AccountsCarousel: React.FC<AccountsCarouselProps> = ({ accounts }) => {
         {scrollState !== 'right' && scrollState !== 'not-needed' && (
           <button
             onClick={scrollRight}
-            className="hidden lg:flex absolute top-0 -right-0.5 h-full w-[104px] bg-gradient-to-r from-transparent to-main-grey items-center justify-end pr-4"
+            className="hidden lg:flex absolute top-0 right-0 h-full w-[104px] bg-gradient-to-r from-transparent to-main-grey items-center justify-end pr-4"
           >
             <div className="w-12 h-8 bg-white rounded-full flex justify-center items-center shadow-small">
               <svg

--- a/apps/business/src/components/ui/molecules/AccountsCarousel.tsx
+++ b/apps/business/src/components/ui/molecules/AccountsCarousel.tsx
@@ -1,8 +1,8 @@
+import * as RadixScrollArea from '@radix-ui/react-scroll-area'
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import AccountSummaryCard from '../../../components/AccountSummaryCard'
-import ScrollArea from '../../../components/ui/ScrollArea'
 import { Account } from '../../../lib/types/localTypes'
 
 interface AccountsCarouselProps {
@@ -66,74 +66,84 @@ const AccountsCarousel: React.FC<AccountsCarouselProps> = ({ accounts }) => {
   }
 
   return (
-    <ScrollArea ref={ref} className="relative" enableCustomScrollbar>
-      {/* Previous arrow */}
-      {scrollState !== 'left' && scrollState !== 'not-needed' && (
-        <button
-          onClick={scrollLeft}
-          className="hidden lg:flex absolute top-0 -left-0.5 h-full w-[104px] bg-gradient-to-l from-transparent to-main-grey  items-center justify-start pr-4"
-        >
-          <div className="w-12 h-8 bg-white rounded-full flex justify-center items-center shadow-small">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="9"
-              height="15"
-              viewBox="0 0 9 15"
-              fill="none"
-            >
-              <path
-                d="M7.66665 14.0003L0.999999 7.33365L7.66665 0.666993"
-                stroke="#454D54"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </div>
-        </button>
-      )}
+    <RadixScrollArea.Root className="">
+      <RadixScrollArea.Viewport ref={ref} className="">
+        {/* Previous arrow */}
+        {scrollState !== 'left' && scrollState !== 'not-needed' && (
+          <button
+            onClick={scrollLeft}
+            className="hidden lg:flex absolute top-0 -left-0.5 h-full w-[104px] bg-gradient-to-l from-transparent to-main-grey items-center justify-start pl-4"
+          >
+            <div className="w-12 h-8 bg-white rounded-full flex justify-center items-center shadow-small">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="9"
+                height="15"
+                viewBox="0 0 9 15"
+                fill="none"
+              >
+                <path
+                  d="M7.66665 14.0003L0.999999 7.33365L7.66665 0.666993"
+                  stroke="#454D54"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </button>
+        )}
 
-      <div className="flex space-x-4">
-        {accounts
-          .sort((a, b) => a.accountName?.localeCompare(b.accountName))
-          .map((account: Account) => {
-            return (
-              <AccountSummaryCard
-                key={account.id}
-                account={account}
-                className="md:snap-center lg:snap-start" // Snap to center when scrolling (only for tablet resolution)
-                onClick={() => {
-                  navigate(`current-accounts/${account.id}`)
-                }}
-              />
-            )
-          })}
-      </div>
+        <div className="flex space-x-4 px-8 md:px-14">
+          {accounts
+            .sort((a, b) => a.accountName?.localeCompare(b.accountName))
+            .map((account: Account) => {
+              return (
+                <AccountSummaryCard
+                  key={account.id}
+                  account={account}
+                  className="md:snap-center lg:snap-start" // Snap to center when scrolling (only for tablet resolution)
+                  onClick={() => {
+                    navigate(`current-accounts/${account.id}`)
+                  }}
+                />
+              )
+            })}
+        </div>
 
-      {/* Next arrow */}
-      {scrollState !== 'right' && scrollState !== 'not-needed' && (
-        <button
-          onClick={scrollRight}
-          className="hidden lg:flex absolute top-0 -right-0.5 h-full w-[104px] bg-gradient-to-r from-transparent to-main-grey items-center justify-end pl-4"
-        >
-          <div className="w-12 h-8 bg-white rounded-full flex justify-center items-center shadow-small">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="9"
-              height="15"
-              viewBox="0 0 9 15"
-              fill="none"
-            >
-              <path
-                d="M1.33335 0.999702L8 7.66635L1.33335 14.333"
-                stroke="#454D54"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </div>
-        </button>
-      )}
-    </ScrollArea>
+        {/* Next arrow */}
+        {scrollState !== 'right' && scrollState !== 'not-needed' && (
+          <button
+            onClick={scrollRight}
+            className="hidden lg:flex absolute top-0 -right-0.5 h-full w-[104px] bg-gradient-to-r from-transparent to-main-grey items-center justify-end pr-4"
+          >
+            <div className="w-12 h-8 bg-white rounded-full flex justify-center items-center shadow-small">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="9"
+                height="15"
+                viewBox="0 0 9 15"
+                fill="none"
+              >
+                <path
+                  d="M1.33335 0.999702L8 7.66635L1.33335 14.333"
+                  stroke="#454D54"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </button>
+        )}
+      </RadixScrollArea.Viewport>
+
+      <RadixScrollArea.Scrollbar
+        forceMount
+        className="select-none md:flex  !relative mx-auto mt-4 overflow-hidden hidden touch-none rounded-lg  h-0.5 w-40 bg-[#E0E7EA] transition-colors duration-[160ms] ease-out hover:bg-gray-200 flex-col"
+        orientation="horizontal"
+      >
+        <RadixScrollArea.Thumb className="flex-1 rounded-lg bg-[#477085]" />
+      </RadixScrollArea.Scrollbar>
+    </RadixScrollArea.Root>
   )
 }
 

--- a/apps/business/src/components/ui/molecules/AccountsCarousel.tsx
+++ b/apps/business/src/components/ui/molecules/AccountsCarousel.tsx
@@ -66,8 +66,8 @@ const AccountsCarousel: React.FC<AccountsCarouselProps> = ({ accounts }) => {
   }
 
   return (
-    <RadixScrollArea.Root className="">
-      <RadixScrollArea.Viewport ref={ref} className="">
+    <RadixScrollArea.Root className="-mt-4">
+      <RadixScrollArea.Viewport ref={ref}>
         {/* Previous arrow */}
         {scrollState !== 'left' && scrollState !== 'not-needed' && (
           <button
@@ -93,7 +93,7 @@ const AccountsCarousel: React.FC<AccountsCarouselProps> = ({ accounts }) => {
           </button>
         )}
 
-        <div className="flex space-x-4 px-8 md:px-14">
+        <div className="flex space-x-4 px-8 md:px-14 py-4">
           {accounts
             .sort((a, b) => a.accountName?.localeCompare(b.accountName))
             .map((account: Account) => {
@@ -138,7 +138,7 @@ const AccountsCarousel: React.FC<AccountsCarouselProps> = ({ accounts }) => {
 
       <RadixScrollArea.Scrollbar
         forceMount
-        className="select-none md:flex  !relative mx-auto mt-4 overflow-hidden hidden touch-none rounded-lg  h-0.5 w-40 bg-[#E0E7EA] transition-colors duration-[160ms] ease-out hover:bg-gray-200 flex-col"
+        className="select-none md:flex !relative mx-auto overflow-hidden hidden touch-none rounded-lg  h-0.5 w-40 bg-[#E0E7EA] transition-colors duration-[160ms] ease-out hover:bg-gray-200 flex-col"
         orientation="horizontal"
       >
         <RadixScrollArea.Thumb className="flex-1 rounded-lg bg-[#477085]" />

--- a/apps/business/src/components/ui/molecules/AccountsCarousel.tsx
+++ b/apps/business/src/components/ui/molecules/AccountsCarousel.tsx
@@ -22,49 +22,56 @@ const AccountsCarousel: React.FC<AccountsCarouselProps> = ({ accounts }) => {
     if (ref.current) {
       if (ref.current.offsetWidth >= ref.current.scrollWidth) {
         setScrollState('not-needed')
+      } else {
+        checkScroll(ref)
       }
 
       ref.current.addEventListener('scroll', () => {
-        const isFullyScrolled =
-          (ref.current?.scrollLeft ?? 0) + (ref.current?.offsetWidth ?? 0) >=
-          (ref.current?.scrollWidth ?? 0)
-        const isScrolledToStart = ref.current?.scrollLeft === 0
-
-        if (isFullyScrolled) {
-          setScrollState('right')
-        }
-
-        if (isScrolledToStart) {
-          setScrollState('left')
-        }
-
-        if (!isFullyScrolled && !isScrolledToStart) {
-          setScrollState('none')
-        }
+        checkScroll(ref)
       })
     }
-  }, [ref])
+  }, [ref.current?.offsetWidth, ref.current?.scrollWidth, ref.current?.scrollLeft])
+
+  const checkScroll = (ref: React.RefObject<HTMLDivElement>) => {
+    const isFullyScrolled =
+      (ref.current?.scrollLeft ?? 0) + (ref.current?.offsetWidth ?? 0) >=
+      (ref.current?.scrollWidth ?? 0)
+    const isScrolledToStart = ref.current?.scrollLeft === 0
+
+    if (isFullyScrolled) {
+      setScrollState('right')
+    }
+
+    if (isScrolledToStart) {
+      setScrollState('left')
+    }
+
+    if (!isFullyScrolled && !isScrolledToStart) {
+      setScrollState('none')
+    }
+  }
 
   const scrollRight = () => {
     ref.current?.scrollTo({
-      left: ref.current?.scrollLeft + ref.current?.offsetWidth,
+      left: ref.current?.scrollLeft + ref.current?.offsetWidth / 2,
       behavior: 'smooth',
     })
   }
 
   const scrollLeft = () => {
     ref.current?.scrollTo({
-      left: ref.current?.scrollLeft - ref.current?.offsetWidth,
+      left: ref.current?.scrollLeft - ref.current?.offsetWidth / 2,
       behavior: 'smooth',
     })
   }
+
   return (
     <ScrollArea ref={ref} className="relative" enableCustomScrollbar>
       {/* Previous arrow */}
       {scrollState !== 'left' && scrollState !== 'not-needed' && (
         <button
           onClick={scrollLeft}
-          className="hidden lg:flex absolute top-0 -left-0.5 h-full w-[104px] bg-gradient-to-l from-transparent to-main-gray  items-center justify-start pr-4"
+          className="hidden lg:flex absolute top-0 -left-0.5 h-full w-[104px] bg-gradient-to-l from-transparent to-main-grey  items-center justify-start pr-4"
         >
           <div className="w-12 h-8 bg-white rounded-full flex justify-center items-center shadow-small">
             <svg
@@ -106,7 +113,7 @@ const AccountsCarousel: React.FC<AccountsCarouselProps> = ({ accounts }) => {
       {scrollState !== 'right' && scrollState !== 'not-needed' && (
         <button
           onClick={scrollRight}
-          className="hidden lg:flex absolute top-0 -right-0.5 h-full w-[104px] bg-gradient-to-r from-transparent to-main-gray items-center justify-end pl-4"
+          className="hidden lg:flex absolute top-0 -right-0.5 h-full w-[104px] bg-gradient-to-r from-transparent to-main-grey items-center justify-end pl-4"
         >
           <div className="w-12 h-8 bg-white rounded-full flex justify-center items-center shadow-small">
             <svg

--- a/apps/business/src/pages/dashboard/page.tsx
+++ b/apps/business/src/pages/dashboard/page.tsx
@@ -67,7 +67,7 @@ const DashboardPage = () => {
     <>
       <h1 className="text-[1.75rem]/8 font-medium mb-8 md:mb-16">Your current status</h1>
       <div className="md:-mx-4">
-        <div className="-mx-8 md:-mx-14 px-8 md:px-14">
+        <div className="-mx-8 md:-mx-14">
           {!isAccountsLoading && accounts && <AccountsCarousel accounts={accounts} />}
         </div>
 


### PR DESCRIPTION
In this pull request:

1. Fixed an issue where the arrows used to scroll through the current account cards weren't visible on initial load. With this fix, arrows will always be displayed if there's a card to be shown, whether on the left or right side of the screen.
2. Updated the card designs to align more closely with the specified design. This includes adding a gradient to the edges near the arrows.

**Important Note**: Due to some limitations, introducing the gradient arrows required a trade-off. The snapping feature on the cards has been removed. Now, clicking on the arrow will scroll a fixed amount of content instead of snapping the card to the beginning. If we kept the snapping feature, cards would align directly to the screen's edge without any padding.