### PR TITLE
Feature/moov 2171 transactions adjustments

### DIFF
--- a/apps/business/src/pages/accounts-receivable/page.tsx
+++ b/apps/business/src/pages/accounts-receivable/page.tsx
@@ -17,7 +17,7 @@ const AccountReceivablePage = () => {
   return (
     // Div is needed to prevent the dashboard from being
     // rendered as two separate components
-    <div className="md:-mx-4">
+    <div>
       <AccountsReceivableDashboard
         merchantId={merchant ? merchant.id : ''}
         apiUrl={NOFRIXION_API_URL}

--- a/apps/business/src/pages/dashboard/page.tsx
+++ b/apps/business/src/pages/dashboard/page.tsx
@@ -65,8 +65,8 @@ const DashboardPage = () => {
 
   return (
     <>
-      <h1 className="text-[1.75rem]/8 font-medium mb-8 md:mb-16">Your current status</h1>
-      <div className="md:-mx-4">
+      <h1 className="text-[1.75rem]/8 font-medium mb-8 md:mb-16 md:px-4">Your current status</h1>
+      <div>
         <div className="-mx-8 md:-mx-14 px-8 md:px-14">
           {!isAccountsLoading && accounts && <AccountsCarousel accounts={accounts} />}
         </div>

--- a/apps/business/src/pages/layout.tsx
+++ b/apps/business/src/pages/layout.tsx
@@ -74,7 +74,7 @@ const Layout = () => {
         <StickyFeedback />
         <Navbar />
         <div className="min-h-full flex">
-          <div className="bg-main-grey w-full pb-28 px-6 md:px-[72px] pt-16 md:pb-16">{outlet}</div>
+          <div className="bg-main-grey w-full pb-28 px-6 md:px-[56px] pt-16 md:pb-16">{outlet}</div>
         </div>
       </div>
     </>

--- a/apps/business/src/pages/pricing/page.tsx
+++ b/apps/business/src/pages/pricing/page.tsx
@@ -124,12 +124,13 @@ const PricingPage: React.FC = () => {
 
   return (
     <>
-      <h1 className="text-[1.75rem]/8 font-medium mb-[10px]">MoneyMoov for Business Packages</h1>
-      <span className="flex text-[#00264D] text-base mb-12">
-        Pricing for up to 5 users. Contact us for Larger / Enterprise pricing.
-      </span>
-
-      <div className="-mx-8 md:-mx-[72px]">
+      <div className="md:px-4">
+        <h1 className="text-[1.75rem]/8 font-medium mb-[10px]">MoneyMoov for Business Packages</h1>
+        <span className="flex text-[#00264D] text-base mb-12">
+          Pricing for up to 5 users. Contact us for Larger / Enterprise pricing.
+        </span>
+      </div>
+      <div className="-mx-8 md:-mx-[56px]">
         <ScrollArea>
           <div className="flex gap-4 px-8 md:px-14">
             {pricingCards.map((card, index) => (
@@ -145,7 +146,7 @@ const PricingPage: React.FC = () => {
         </ScrollArea>
       </div>
 
-      <div className="mb-8 pl-6">
+      <div className="mb-8 pl-4">
         <span className="flex text-[#00264D] text-sm leading-6">
           + Additional SEPA transactions: €0.25 / transaction.
         </span>
@@ -191,7 +192,7 @@ const PricingPage: React.FC = () => {
         </div>
           </div>*/}
 
-      <div className="mb-4 mt-12">
+      <div className="mb-4 mt-12 md:px-4">
         <h1 className="text-[1.75rem]/8 font-medium mb-[10px]">Addtional Fees</h1>
       </div>
 

--- a/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -530,8 +530,8 @@ const PaymentRequestDashboardMain = ({
 
   return (
     <div className="font-inter bg-main-grey text-default-text h-full">
-      <div className="flex gap-8 justify-between items-center mb-8 md:mb-[68px]">
-        <span className="md:pl-4 leading-8 font-medium text-2xl md:text-[1.75rem]">
+      <div className="flex gap-8 justify-between items-center mb-8 md:mb-[68px] md:px-4">
+        <span className="leading-8 font-medium text-2xl md:text-[1.75rem]">
           Accounts Receivable
         </span>
         <LayoutGroup>

--- a/packages/components/src/components/ui/Account/AccountBalance/AccountBalance.tsx
+++ b/packages/components/src/components/ui/Account/AccountBalance/AccountBalance.tsx
@@ -22,7 +22,7 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
       <span className="text-[32px] font-semibold leading-9 tabular-nums font-inter-fontFeatureSettings">
         {formatCurrency(currency)} {formatAmount(balance)}
       </span>
-      <div className="text-sm font-normal leading-4 mt-2">
+      <div className="text-sm font-normal leading-4 mt-2 mr-1">
         <span className="pr-2">Available</span>
         <span className="tabular-nums font-inter-fontFeatureSettings">
           {formatCurrency(currency)} {formatAmount(availableBalance)}

--- a/packages/components/src/components/ui/Account/CurrentAccountsHeader/CurrentAccountsHeader .tsx
+++ b/packages/components/src/components/ui/Account/CurrentAccountsHeader/CurrentAccountsHeader .tsx
@@ -6,10 +6,8 @@ export interface CurrentAccountsHeaderProps {
 
 const CurrentAccountsHeader = ({ onCreatePaymentAccount }: CurrentAccountsHeaderProps) => {
   return (
-    <div className="flex gap-8 justify-between items-center mb-8 md:mb-[68px]">
-      <span className="md:pl-4 leading-8 font-medium text-2xl md:text-[1.75rem]">
-        Currents accounts
-      </span>
+    <div className="flex gap-8 justify-between items-center mb-8 md:mb-[68px] md:px-4">
+      <span className="leading-8 font-medium text-2xl md:text-[1.75rem]">Currents accounts</span>
       <div className="w-[172px]">
         {onCreatePaymentAccount && (
           <Button size="big" onClick={onCreatePaymentAccount} variant="secondary">

--- a/packages/components/src/components/ui/PendingPayments/PendingPayments.tsx
+++ b/packages/components/src/components/ui/PendingPayments/PendingPayments.tsx
@@ -44,9 +44,11 @@ export const PendingPayments: React.FC<PendingPaymentsProps> = ({
                     key={payment.id}
                     className="flex justify-between py-2 text-xs items-center text-default-text flex-shrink-0 border-t font-normal"
                   >
-                    <span className="mr-4 w-[128px] text-default-text">{payment.createdBy}</span>
-                    <span className="">{payment.description}</span>
-                    <span className="text-right font-medium tabular-nums font-inter-fontFeatureSettings">
+                    <div className="flex text-default-text text-left">
+                      <span className="mr-4 w-[128px] ">{payment.createdBy}</span>
+                      <span className="w-[144px]">{payment.description}</span>
+                    </div>
+                    <span className="text-right font-medium tabular-nums font-inter-fontFeatureSettings whitespace-nowrap ml-4">
                       - {formatCurrency(payment.currency)} {formatAmount(payment.amount)}
                     </span>
                   </div>

--- a/packages/components/src/components/ui/organisms/TransactionsTable/TransactionsTable.tsx
+++ b/packages/components/src/components/ui/organisms/TransactionsTable/TransactionsTable.tsx
@@ -74,7 +74,10 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
             </TableHeader>
             <TableBody>
               {transactions.map((transaction, index) => (
-                <TableRow key={`${transaction}-${index}`}>
+                <TableRow
+                  className="cursor-auto hover:bg-inherit hover:border-inherit"
+                  key={`${transaction}-${index}`}
+                >
                   <TableCell>
                     {renderBasicInfoLayout(
                       format(transaction.date, 'MMM dd, yyyy'),

--- a/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
@@ -45,11 +45,11 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
 }) => {
   return (
     <>
-      <div className="mb-12">
+      <div className="mb-12 md:px-4">
         <div className="flex justify-between">
           <button onClick={onAllCurrentAccountsClick} className="flex items-center space-x-3">
             <Icon name="back/12" />
-            <span>All current accounts</span>
+            <span className="hover:underline">All current accounts</span>
           </button>
           {/* TODO: Implement download statement feature*/}
           {/* <div>


### PR DESCRIPTION
- Underline hover state for back for accounts.
- Fix padding on pages to 56px and additional 16px for headers. Remove the minus margins.
- Account balance - add 4px margin on the available balance.
- Removed the hover states and cursor on transactions with the help of Pablo M.
-Fixed some alignments on pending payments. 