### PR TITLE
Sort payment attempts

### DIFF
--- a/packages/components/src/components/ui/Transactions/Transactions.tsx
+++ b/packages/components/src/components/ui/Transactions/Transactions.tsx
@@ -243,7 +243,7 @@ const Transactions = ({
                               <span className="mr-2 p-1.5">
                                 <Icon name="return/12" className="text-control-grey-hover" />
                               </span>
-                              <span>Refund</span>
+                              <span>Refunded</span>
                             </div>
                           </td>
                         )}
@@ -253,7 +253,7 @@ const Transactions = ({
                               <span className="mr-2 p-1.5">
                                 <Icon name="void/12" className="text-control-grey-hover" />
                               </span>
-                              <span>Void</span>
+                              <span>Voided</span>
                             </div>
                           </td>
                         )}

--- a/packages/components/src/utils/parsers.ts
+++ b/packages/components/src/utils/parsers.ts
@@ -243,46 +243,50 @@ const remotePaymentRequestToLocalPaymentRequest = (
       return []
     } else {
       const localPaymentAttempts: LocalPaymentAttempt[] = []
-      remotePaymentAttempts.map((remotePaymentAttempt) => {
-        if (
-          remotePaymentAttempt.settledAt ||
-          remotePaymentAttempt.authorisedAt ||
-          remotePaymentAttempt.cardAuthorisedAt
-        ) {
-          const {
-            attemptKey,
-            authorisedAt,
-            settledAt,
-            attemptedAmount,
-            paymentMethod,
-            settledAmount,
-            captureAttempts,
-            refundAttempts,
-            currency,
-            walletName,
-            status,
-            authorisedAmount,
-            cardAuthorisedAmount,
-            cardAuthorisedAt,
-          } = remotePaymentAttempt
+      remotePaymentAttempts
+        .sort((a, b) => {
+          return new Date(b.initiatedAt ?? 0).getTime() - new Date(a.initiatedAt ?? 0).getTime()
+        })
+        .map((remotePaymentAttempt) => {
+          if (
+            remotePaymentAttempt.settledAt ||
+            remotePaymentAttempt.authorisedAt ||
+            remotePaymentAttempt.cardAuthorisedAt
+          ) {
+            const {
+              attemptKey,
+              authorisedAt,
+              settledAt,
+              attemptedAmount,
+              paymentMethod,
+              settledAmount,
+              captureAttempts,
+              refundAttempts,
+              currency,
+              walletName,
+              status,
+              authorisedAmount,
+              cardAuthorisedAmount,
+              cardAuthorisedAt,
+            } = remotePaymentAttempt
 
-          localPaymentAttempts.push({
-            attemptKey: attemptKey,
-            occurredAt: new Date(settledAt ?? authorisedAt ?? cardAuthorisedAt ?? 0),
-            paymentMethod: parseApiPaymentMethodTypeToLocalMethodType(paymentMethod),
-            amount: attemptedAmount,
-            currency: currency,
-            processor: walletName ? parseApiWalletTypeToLocalWalletType(walletName) : undefined,
-            settledAmount: settledAmount,
-            captureAttempts: parseApiCaptureAttemptsToLocalCaptureAttempts(captureAttempts),
-            refundAttempts: parseApiRefundAttemptsToLocalRefundAttempts(refundAttempts),
-            authorisedAmount: authorisedAmount,
-            cardAuthorisedAmount: cardAuthorisedAmount,
-            wallet: walletName ? parseApiWalletTypeToLocalWalletType(walletName) : undefined,
-            status: parseApiStatusToLocalStatus(status),
-          })
-        }
-      })
+            localPaymentAttempts.push({
+              attemptKey: attemptKey,
+              occurredAt: new Date(settledAt ?? authorisedAt ?? cardAuthorisedAt ?? 0),
+              paymentMethod: parseApiPaymentMethodTypeToLocalMethodType(paymentMethod),
+              amount: attemptedAmount,
+              currency: currency,
+              processor: walletName ? parseApiWalletTypeToLocalWalletType(walletName) : undefined,
+              settledAmount: settledAmount,
+              captureAttempts: parseApiCaptureAttemptsToLocalCaptureAttempts(captureAttempts),
+              refundAttempts: parseApiRefundAttemptsToLocalRefundAttempts(refundAttempts),
+              authorisedAmount: authorisedAmount,
+              cardAuthorisedAmount: cardAuthorisedAmount,
+              wallet: walletName ? parseApiWalletTypeToLocalWalletType(walletName) : undefined,
+              status: parseApiStatusToLocalStatus(status),
+            })
+          }
+        })
       return localPaymentAttempts
     }
   }


### PR DESCRIPTION
The payment attempts are now order by descending order so latest first. 

Fix for #MOOV-2161 and #MOOV-2162

![old_events](https://github.com/nofrixion/nofrixion.business/assets/92720032/da846266-7dee-4cf1-86f1-744e71264f7c)
![new_events](https://github.com/nofrixion/nofrixion.business/assets/92720032/d993d29e-7879-40cc-8d2d-cdf5fe2134c3)
