### PR TITLE
Add account-dashboard Web Component

### DIFF
--- a/packages/web-components/src/AccountDashboard.tsx
+++ b/packages/web-components/src/AccountDashboard.tsx
@@ -1,0 +1,16 @@
+import ReactDOM from 'react-dom/client'
+import { AccountDashboard } from '@nofrixion/components'
+import r2wc from 'react-to-webcomponent'
+import React from 'react'
+
+const DashBoard = r2wc(AccountDashboard, React, ReactDOM, {
+  props: {
+    token: 'string',
+    apiUrl: 'string',
+    accountId: 'string',
+    merchantId: 'string',
+    onAllCurrentAccountsClick: 'function',
+  },
+})
+
+customElements.define('account-dashboard', DashBoard)

--- a/packages/web-components/src/AccountDashboard.tsx
+++ b/packages/web-components/src/AccountDashboard.tsx
@@ -3,7 +3,7 @@ import { AccountDashboard } from '@nofrixion/components'
 import r2wc from 'react-to-webcomponent'
 import React from 'react'
 
-const DashBoard = r2wc(AccountDashboard, React, ReactDOM, {
+const AccountDashboardWebComponent = r2wc(AccountDashboard, React, ReactDOM, {
   props: {
     token: 'string',
     apiUrl: 'string',
@@ -13,4 +13,4 @@ const DashBoard = r2wc(AccountDashboard, React, ReactDOM, {
   },
 })
 
-customElements.define('account-dashboard', DashBoard)
+customElements.define('account-dashboard', AccountDashboardWebComponent)

--- a/packages/web-components/src/AccountsReceivableDashboard.tsx
+++ b/packages/web-components/src/AccountsReceivableDashboard.tsx
@@ -3,7 +3,7 @@ import { AccountsReceivable } from '@nofrixion/components'
 import r2wc from 'react-to-webcomponent'
 import React from 'react'
 
-const DashBoard = r2wc(AccountsReceivable, React, ReactDOM, {
+const AccountsReceivableWebComponent = r2wc(AccountsReceivable, React, ReactDOM, {
   props: {
     token: 'string',
     apiUrl: 'string',
@@ -11,4 +11,4 @@ const DashBoard = r2wc(AccountsReceivable, React, ReactDOM, {
   },
 })
 
-customElements.define('payment-request-dashboard', DashBoard)
+customElements.define('payment-request-dashboard', AccountsReceivableWebComponent)

--- a/packages/web-components/src/CurrentAccountsList.tsx
+++ b/packages/web-components/src/CurrentAccountsList.tsx
@@ -3,7 +3,7 @@ import { AccountsList } from '@nofrixion/components'
 import r2wc from 'react-to-webcomponent'
 import React from 'react'
 
-const DashBoard = r2wc(AccountsList, React, ReactDOM, {
+const CurrentAccountsListWebComponent = r2wc(AccountsList, React, ReactDOM, {
   props: {
     token: 'string',
     apiUrl: 'string',
@@ -12,4 +12,4 @@ const DashBoard = r2wc(AccountsList, React, ReactDOM, {
   },
 })
 
-customElements.define('current-accounts-list', DashBoard)
+customElements.define('current-accounts-list', CurrentAccountsListWebComponent)

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -2,3 +2,4 @@
 // need to be imported here
 import './AccountsReceivableDashboard'
 import './CurrentAccountsList'
+import './AccountDashboard'


### PR DESCRIPTION
This pull request includes the addition of the `account-dashboard` web component.

Notes:

- The component has been tested locally by incorporating it into the Portal, and it appears to work as expected.
- A follow-up PR will be created on the MoneyMoov Portal (API solution) to display the new Accounts Dashboard.