### PR TITLE
Fix Exit Animation Bug in Payment Request Details Modal

### DIFF
--- a/packages/components/src/components/functional/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
+++ b/packages/components/src/components/functional/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
@@ -217,24 +217,20 @@ const PaymentRequestDetailsModal = ({
   }
 
   return (
-    <div>
-      {/* {paymentRequest && ( */}
-      <UIPaymentRequestDetailsModal
-        merchantTags={merchantTags}
-        paymentRequest={paymentRequest}
-        hostedPaymentLink={`${paymentRequest?.hostedPayCheckoutUrl}`}
-        open={open}
-        accounts={accounts}
-        onCardRefund={onCardRefund}
-        onBankRefund={onBankRefund}
-        onCapture={onCapture}
-        onTagAdded={onTagAdded}
-        onTagCreated={onTagCreated}
-        onTagDeleted={onTagDeleted}
-        onDismiss={onModalDismiss}
-      />
-      {/* )} */}
-    </div>
+    <UIPaymentRequestDetailsModal
+      merchantTags={merchantTags}
+      paymentRequest={paymentRequest}
+      hostedPaymentLink={`${paymentRequest?.hostedPayCheckoutUrl}`}
+      open={open}
+      accounts={accounts}
+      onCardRefund={onCardRefund}
+      onBankRefund={onBankRefund}
+      onCapture={onCapture}
+      onTagAdded={onTagAdded}
+      onTagCreated={onTagCreated}
+      onTagDeleted={onTagDeleted}
+      onDismiss={onModalDismiss}
+    />
   )
 }
 

--- a/packages/components/src/components/functional/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
+++ b/packages/components/src/components/functional/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
@@ -218,22 +218,22 @@ const PaymentRequestDetailsModal = ({
 
   return (
     <div>
-      {paymentRequest && (
-        <UIPaymentRequestDetailsModal
-          merchantTags={merchantTags}
-          paymentRequest={paymentRequest}
-          hostedPaymentLink={`${paymentRequest.hostedPayCheckoutUrl}`}
-          open={open}
-          accounts={accounts}
-          onCardRefund={onCardRefund}
-          onBankRefund={onBankRefund}
-          onCapture={onCapture}
-          onTagAdded={onTagAdded}
-          onTagCreated={onTagCreated}
-          onTagDeleted={onTagDeleted}
-          onDismiss={onModalDismiss}
-        ></UIPaymentRequestDetailsModal>
-      )}
+      {/* {paymentRequest && ( */}
+      <UIPaymentRequestDetailsModal
+        merchantTags={merchantTags}
+        paymentRequest={paymentRequest}
+        hostedPaymentLink={`${paymentRequest?.hostedPayCheckoutUrl}`}
+        open={open}
+        accounts={accounts}
+        onCardRefund={onCardRefund}
+        onBankRefund={onBankRefund}
+        onCapture={onCapture}
+        onTagAdded={onTagAdded}
+        onTagCreated={onTagCreated}
+        onTagDeleted={onTagDeleted}
+        onDismiss={onModalDismiss}
+      />
+      {/* )} */}
     </div>
   )
 }

--- a/packages/components/src/components/ui/BankRefundModal/BankRefundModal.tsx
+++ b/packages/components/src/components/ui/BankRefundModal/BankRefundModal.tsx
@@ -47,7 +47,7 @@ const BankRefundModal: React.FC<BankRefundModalProps> = ({
     (t) => t.id === bankPaymentAttempt?.reconciledTransactionID,
   )?.counterParty
 
-  const defaultSourceAccount = accounts.find((a) => a.id === paymentRequest?.pispAccountID)
+  const defaultSourceAccount = accounts?.find((a) => a.id === paymentRequest?.pispAccountID)
   const formatter = new Intl.NumberFormat(navigator.language, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,

--- a/packages/components/src/components/ui/CopyLink/CopyLink.tsx
+++ b/packages/components/src/components/ui/CopyLink/CopyLink.tsx
@@ -23,10 +23,7 @@ export const CopyLink = ({ link }: { link: string }) => {
   }
 
   return (
-    <div
-      tabIndex={-2}
-      className="flex items-center h-10 rounded-full justify-between px-4 pr-4 shadow-[0_0_0.5rem_rgba(4,41,49,0.15)] text-[0.813rem] relative bg-white"
-    >
+    <div className="flex items-center h-10 rounded-full justify-between px-4 pr-4 shadow-[0_0_0.5rem_rgba(4,41,49,0.15)] text-[0.813rem] relative bg-white">
       <span className="whitespace-nowrap overflow-x-clip">{link}</span>
       <div className="w-14 h-6 bg-gradient-to-l from-white right-[5.5rem] absolute pointer-events-none"></div>
       <AnimatePresence>

--- a/packages/components/src/components/ui/CopyLink/CopyLink.tsx
+++ b/packages/components/src/components/ui/CopyLink/CopyLink.tsx
@@ -23,7 +23,10 @@ export const CopyLink = ({ link }: { link: string }) => {
   }
 
   return (
-    <div className="flex items-center h-10 rounded-full justify-between px-4 pr-4 shadow-[0_0_0.5rem_rgba(4,41,49,0.15)] text-[0.813rem] relative bg-white">
+    <div
+      tabIndex={-2}
+      className="flex items-center h-10 rounded-full justify-between px-4 pr-4 shadow-[0_0_0.5rem_rgba(4,41,49,0.15)] text-[0.813rem] relative bg-white"
+    >
       <span className="whitespace-nowrap overflow-x-clip">{link}</span>
       <div className="w-14 h-6 bg-gradient-to-l from-white right-[5.5rem] absolute pointer-events-none"></div>
       <AnimatePresence>

--- a/packages/components/src/components/ui/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
+++ b/packages/components/src/components/ui/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
@@ -21,7 +21,7 @@ import CardRefundModal from '../CardRefundModal/CardRefundModal'
 import PaymentRequestDetails from '../PaymentRequestDetails/PaymentRequestDetails'
 
 export interface PaymentRequestDetailsModalProps {
-  paymentRequest: LocalPaymentRequest
+  paymentRequest?: LocalPaymentRequest
   merchantTags: LocalTag[]
   hostedPaymentLink: string
   onCardRefund: (authorizationID: string, amount: number, isCardVoid: boolean) => Promise<void>
@@ -165,7 +165,7 @@ const PaymentRequestDetailsModal = ({
         <SheetContent className="w-full lg:w-[37.5rem]">
           <div className="bg-white max-h-full h-full overflow-auto">
             <div className="max-h-full h-full">
-              <div className="h-fit pb-16 lg:pb-0">
+              {paymentRequest && (
                 <PaymentRequestDetails
                   paymentRequest={paymentRequest}
                   merchantTags={merchantTags}
@@ -181,7 +181,7 @@ const PaymentRequestDetailsModal = ({
                   onTagDeleted={onTagDeleted}
                   onTagCreated={onTagCreated}
                 ></PaymentRequestDetails>
-              </div>
+              )}
             </div>
           </div>
         </SheetContent>
@@ -191,18 +191,20 @@ const PaymentRequestDetailsModal = ({
         <SheetContent className="w-full lg:w-[37.5rem]">
           <div className="bg-white max-h-full h-full overflow-auto">
             <div className="max-h-full h-full">
-              <CaptureModal
-                onCapture={onCaptureConfirm}
-                onDismiss={onCaptureDismiss}
-                initialAmount={amountToCapture ?? '0'}
-                maxCapturableAmount={maxCapturableAmount}
-                currency={selectedTransactionForCapture?.currency ?? Currency.EUR}
-                setAmountToCapture={setAmountToCapture}
-                transactionDate={selectedTransactionForCapture?.occurredAt ?? new Date()}
-                contactName={paymentRequest.contact.name}
-                lastFourDigitsOnCard={selectedTransactionForCapture?.last4DigitsOfCardNumber}
-                processor={selectedTransactionForCapture?.processor}
-              />
+              {paymentRequest && (
+                <CaptureModal
+                  onCapture={onCaptureConfirm}
+                  onDismiss={onCaptureDismiss}
+                  initialAmount={amountToCapture ?? '0'}
+                  maxCapturableAmount={maxCapturableAmount}
+                  currency={selectedTransactionForCapture?.currency ?? Currency.EUR}
+                  setAmountToCapture={setAmountToCapture}
+                  transactionDate={selectedTransactionForCapture?.occurredAt ?? new Date()}
+                  contactName={paymentRequest.contact.name}
+                  lastFourDigitsOnCard={selectedTransactionForCapture?.last4DigitsOfCardNumber}
+                  processor={selectedTransactionForCapture?.processor}
+                />
+              )}
             </div>
           </div>
         </SheetContent>
@@ -212,29 +214,31 @@ const PaymentRequestDetailsModal = ({
         <SheetContent className="w-full lg:w-[37.5rem]">
           <div className="bg-white max-h-full h-full overflow-auto">
             <div className="max-h-full h-full">
-              <CardRefundModal
-                onRefund={onCardRefundConfirm}
-                onDismiss={onRefundDismiss}
-                initialAmount={amountToRefund ?? '0'}
-                maxRefundableAmount={maxCardRefundableAmount}
-                currency={selectedTransactionForCardRefund?.currency ?? Currency.EUR}
-                setAmountToRefund={setAmountToRefund}
-                transactionDate={selectedTransactionForCardRefund?.occurredAt ?? new Date()}
-                contactName={paymentRequest.contact.name}
-                lastFourDigitsOnCard={selectedTransactionForCardRefund?.last4DigitsOfCardNumber}
-                processor={selectedTransactionForCardRefund?.processor}
-                isVoid={isCardVoid}
-              />
+              {paymentRequest && (
+                <CardRefundModal
+                  onRefund={onCardRefundConfirm}
+                  onDismiss={onRefundDismiss}
+                  initialAmount={amountToRefund ?? '0'}
+                  maxRefundableAmount={maxCardRefundableAmount}
+                  currency={selectedTransactionForCardRefund?.currency ?? Currency.EUR}
+                  setAmountToRefund={setAmountToRefund}
+                  transactionDate={selectedTransactionForCardRefund?.occurredAt ?? new Date()}
+                  contactName={paymentRequest.contact.name}
+                  lastFourDigitsOnCard={selectedTransactionForCardRefund?.last4DigitsOfCardNumber}
+                  processor={selectedTransactionForCardRefund?.processor}
+                  isVoid={isCardVoid}
+                />
+              )}
             </div>
           </div>
         </SheetContent>
       </Sheet>
 
-      {selectedTransactionForBankRefund && (
+      {selectedTransactionForBankRefund && accounts && accounts?.length > 0 && paymentRequest && (
         <BankRefundModal
           onRefund={onBankRefund}
           onDismiss={onRefundDismiss}
-          accounts={accounts.filter((account) => account.currency === paymentRequest.currency)}
+          accounts={accounts?.filter((account) => account.currency === paymentRequest.currency)}
           paymentRequest={paymentRequest}
           bankPaymentAttempt={selectedTransactionForBankRefund}
         />

--- a/packages/components/src/components/ui/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
+++ b/packages/components/src/components/ui/PaymentRequestDetailsModal/PaymentRequestDetailsModal.tsx
@@ -162,7 +162,12 @@ const PaymentRequestDetailsModal = ({
   return (
     <>
       <Sheet open={open} onOpenChange={handleOnOpenChange}>
-        <SheetContent className="w-full lg:w-[37.5rem]">
+        <SheetContent
+          onOpenAutoFocus={(event) => {
+            event.preventDefault()
+          }}
+          className="w-full lg:w-[37.5rem]"
+        >
           <div className="bg-white max-h-full h-full overflow-auto">
             <div className="max-h-full h-full">
               {paymentRequest && (


### PR DESCRIPTION
This pull request addresses an issue with the exit animation when closing the Payment Request details modal.

1. **Problem**: Previously, the modal was abruptly closed due to a condition that prevented its rendering.
2. **Solution**: Modified the PR object to be nullable and adapted the modal to this change. This resolved the exit animation bug.
3. **Additional Fixes**: After the main fix, a few animation inconsistencies were noticed and subsequently corrected. A new focused state of the modal was challenging to remove, but it was successfully addressed by preventing the event using the `onOpenAutoFocus` function property.