### PR TITLE
Empty state issue fix

### DIFF
--- a/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -42,6 +42,7 @@ import CreatePaymentRequestPage from '../../functional/CreatePaymentRequestPage/
 import { SortDirection } from '../../ui/ColumnHeader/ColumnHeader'
 import { DateRange } from '../../ui/DateRangePicker/DateRangePicker'
 import FilterControlsRow from '../../ui/FilterControlsRow/FilterControlsRow'
+import { Loader } from '../../ui/Loader/Loader'
 import EmptyState from '../../ui/PaymentRequestTable/EmptyState'
 import PaymentRequestTable from '../../ui/PaymentRequestTable/PaymentRequestTable'
 import ScrollArea from '../../ui/ScrollArea/ScrollArea'
@@ -543,15 +544,17 @@ const PaymentRequestDashboardMain = ({
 
   const isInitialState = !isLoadingMetrics && (!firstMetrics || firstMetrics?.all === 0)
 
+  const paymentRequestsExists = !isLoadingMetrics && firstMetrics && firstMetrics?.all > 0
+
   return (
     <div className="font-inter bg-main-grey text-default-text h-full">
-      <div className="flex gap-8 justify-between h-10 items-center mb-8 md:mb-[68px] md:px-4">
-        <span className="leading-8 font-medium text-2xl md:text-[1.75rem] h-10">
+      <div className="flex gap-8 justify-between items-center mb-8 md:mb-[68px] md:px-4">
+        <span className="leading-8 font-medium text-2xl md:text-[1.75rem]">
           Accounts Receivable
         </span>
         <LayoutGroup>
           <AnimatePresence initial={false}>
-            {!isInitialState && (
+            {paymentRequestsExists && (
               <LayoutWrapper>
                 <Button
                   size="big"
@@ -568,7 +571,7 @@ const PaymentRequestDashboardMain = ({
       </div>
 
       <AnimatePresence>
-        {!isInitialState && (
+        {paymentRequestsExists && (
           <div className="mb-4">
             <FilterControlsRow
               setDateRange={setDateRange}
@@ -599,7 +602,7 @@ const PaymentRequestDashboardMain = ({
 
       <LayoutGroup>
         <AnimatePresence initial={false}>
-          {!isInitialState && (
+          {paymentRequestsExists && (
             <LayoutWrapper className="h-full">
               <ScrollArea hideScrollbar>
                 <Tabs.Root
@@ -658,7 +661,7 @@ const PaymentRequestDashboardMain = ({
         </AnimatePresence>
 
         <AnimatePresence initial={false}>
-          {!isInitialState && (
+          {paymentRequestsExists && (
             <LayoutWrapper className="lg:bg-white lg:min-h-[18rem] lg:py-10 lg:px-6  lg:rounded-lg">
               <PaymentRequestTable
                 paymentRequests={localPaymentRequests}
@@ -673,7 +676,6 @@ const PaymentRequestDashboardMain = ({
                 onPaymentRequestDeleteClicked={onDeletePaymentRequest}
                 onPaymentRequestCopyLinkClicked={onCopyPaymentRequestLink}
                 isLoading={isLoadingPaymentRequests}
-                isEmpty={isInitialState}
                 onCreatePaymentRequest={onCreatePaymentRequest}
                 onPaymentRequestClicked={onPaymentRequestRowClicked}
                 onOpenPaymentPage={onOpenPaymentPage}
@@ -696,22 +698,21 @@ const PaymentRequestDashboardMain = ({
             </LayoutWrapper>
           )}
         </AnimatePresence>
-        {/* Show empty state when contet has loaded and no there are no payment requests*/}
-        {/* or also show when isEmpty property comes as `true` */}
+
+        {/* Show loader until metrics are loaded which will determine whether we have any payment requests or not.*/}
+        {isLoadingMetrics && (
+          <div className="lg:min-h-[18rem] lg:py-10 lg:px-6  lg:rounded-lg flex items-center justify-center">
+            <Loader />
+          </div>
+        )}
       </LayoutGroup>
 
       <div>
         <AnimatePresence>
           {isInitialState && (
-            // If `isEmpty` is true means that there're are no payment requests at all, no matter which tab is selected
-            // Else,  there are no payment requests matching the filters
-            <LayoutWrapper className="lg:bg-white lg:min-h-[18rem] lg:py-10 lg:px-6  lg:rounded-lg">
-              <div>
-                <EmptyState
-                  state={isInitialState ? 'empty' : 'nothingFound'}
-                  onCreatePaymentRequest={onCreatePaymentRequest}
-                />
-              </div>
+            // If `isInitialState` is true means that there're are no payment requests at all, no matter which tab is selected
+            <LayoutWrapper className="lg:bg-white lg:min-h-[18rem] lg:py-10 lg:px-6">
+              <EmptyState state="empty" onCreatePaymentRequest={onCreatePaymentRequest} />
             </LayoutWrapper>
           )}
         </AnimatePresence>

--- a/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -42,6 +42,7 @@ import CreatePaymentRequestPage from '../../functional/CreatePaymentRequestPage/
 import { SortDirection } from '../../ui/ColumnHeader/ColumnHeader'
 import { DateRange } from '../../ui/DateRangePicker/DateRangePicker'
 import FilterControlsRow from '../../ui/FilterControlsRow/FilterControlsRow'
+import EmptyState from '../../ui/PaymentRequestTable/EmptyState'
 import PaymentRequestTable from '../../ui/PaymentRequestTable/PaymentRequestTable'
 import ScrollArea from '../../ui/ScrollArea/ScrollArea'
 import Tab from '../../ui/Tab/Tab'
@@ -544,8 +545,8 @@ const PaymentRequestDashboardMain = ({
 
   return (
     <div className="font-inter bg-main-grey text-default-text h-full">
-      <div className="flex gap-8 justify-between items-center mb-8 md:mb-[68px] md:px-4">
-        <span className="leading-8 font-medium text-2xl md:text-[1.75rem]">
+      <div className="flex gap-8 justify-between h-10 items-center mb-8 md:mb-[68px] md:px-4">
+        <span className="leading-8 font-medium text-2xl md:text-[1.75rem] h-10">
           Accounts Receivable
         </span>
         <LayoutGroup>
@@ -656,42 +657,65 @@ const PaymentRequestDashboardMain = ({
           )}
         </AnimatePresence>
 
-        <LayoutWrapper className="lg:bg-white lg:min-h-[18rem] lg:py-10 lg:px-6 lg:rounded-lg">
-          <PaymentRequestTable
-            paymentRequests={localPaymentRequests}
-            pageSize={pageSize}
-            totalRecords={totalRecords}
-            onPageChanged={setPage}
-            setStatusSortDirection={setStatusSortDirection}
-            setCreatedSortDirection={setCreatedSortDirection}
-            setContactSortDirection={setContactSortDirection}
-            setAmountSortDirection={setAmountSortDirection}
-            onPaymentRequestDuplicateClicked={onDuplicatePaymentRequest}
-            onPaymentRequestDeleteClicked={onDeletePaymentRequest}
-            onPaymentRequestCopyLinkClicked={onCopyPaymentRequestLink}
-            isLoading={isLoadingPaymentRequests}
-            isEmpty={isInitialState}
-            onCreatePaymentRequest={onCreatePaymentRequest}
-            onPaymentRequestClicked={onPaymentRequestRowClicked}
-            onOpenPaymentPage={onOpenPaymentPage}
-            selectedPaymentRequestID={selectedPaymentRequestID}
-          />
+        <AnimatePresence initial={false}>
+          {!isInitialState && (
+            <LayoutWrapper className="lg:bg-white lg:min-h-[18rem] lg:py-10 lg:px-6  lg:rounded-lg">
+              <PaymentRequestTable
+                paymentRequests={localPaymentRequests}
+                pageSize={pageSize}
+                totalRecords={totalRecords}
+                onPageChanged={setPage}
+                setStatusSortDirection={setStatusSortDirection}
+                setCreatedSortDirection={setCreatedSortDirection}
+                setContactSortDirection={setContactSortDirection}
+                setAmountSortDirection={setAmountSortDirection}
+                onPaymentRequestDuplicateClicked={onDuplicatePaymentRequest}
+                onPaymentRequestDeleteClicked={onDeletePaymentRequest}
+                onPaymentRequestCopyLinkClicked={onCopyPaymentRequestLink}
+                isLoading={isLoadingPaymentRequests}
+                isEmpty={isInitialState}
+                onCreatePaymentRequest={onCreatePaymentRequest}
+                onPaymentRequestClicked={onPaymentRequestRowClicked}
+                onOpenPaymentPage={onOpenPaymentPage}
+                selectedPaymentRequestID={selectedPaymentRequestID}
+              />
 
-          {!isInitialState && localPaymentRequests.length < totalRecords && (
-            <div className="flex">
-              <Button
-                variant="tertiary"
-                size="big"
-                onClick={fetchNextPage}
-                disabled={isLoadingMore}
-                className="lg:hidden mx-auto mt-6 mb-2 w-fit"
-              >
-                Show more
-              </Button>
-            </div>
+              {!isInitialState && localPaymentRequests.length < totalRecords && (
+                <div className="flex">
+                  <Button
+                    variant="tertiary"
+                    size="big"
+                    onClick={fetchNextPage}
+                    disabled={isLoadingMore}
+                    className="lg:hidden mx-auto mt-6 mb-2 w-fit"
+                  >
+                    Show more
+                  </Button>
+                </div>
+              )}
+            </LayoutWrapper>
           )}
-        </LayoutWrapper>
+        </AnimatePresence>
+        {/* Show empty state when contet has loaded and no there are no payment requests*/}
+        {/* or also show when isEmpty property comes as `true` */}
       </LayoutGroup>
+
+      <div>
+        <AnimatePresence>
+          {isInitialState && (
+            // If `isEmpty` is true means that there're are no payment requests at all, no matter which tab is selected
+            // Else,  there are no payment requests matching the filters
+            <LayoutWrapper className="lg:bg-white lg:min-h-[18rem] lg:py-10 lg:px-6  lg:rounded-lg">
+              <div>
+                <EmptyState
+                  state={isInitialState ? 'empty' : 'nothingFound'}
+                  onCreatePaymentRequest={onCreatePaymentRequest}
+                />
+              </div>
+            </LayoutWrapper>
+          )}
+        </AnimatePresence>
+      </div>
 
       <CreatePaymentRequestPage
         isOpen={isCreatePaymentRequestOpen}

--- a/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -660,44 +660,42 @@ const PaymentRequestDashboardMain = ({
           )}
         </AnimatePresence>
 
-        <AnimatePresence initial={false}>
-          {paymentRequestsExists && (
-            <LayoutWrapper className="lg:bg-white lg:min-h-[18rem] lg:py-10 lg:px-6  lg:rounded-lg">
-              <PaymentRequestTable
-                paymentRequests={localPaymentRequests}
-                pageSize={pageSize}
-                totalRecords={totalRecords}
-                onPageChanged={setPage}
-                setStatusSortDirection={setStatusSortDirection}
-                setCreatedSortDirection={setCreatedSortDirection}
-                setContactSortDirection={setContactSortDirection}
-                setAmountSortDirection={setAmountSortDirection}
-                onPaymentRequestDuplicateClicked={onDuplicatePaymentRequest}
-                onPaymentRequestDeleteClicked={onDeletePaymentRequest}
-                onPaymentRequestCopyLinkClicked={onCopyPaymentRequestLink}
-                isLoading={isLoadingPaymentRequests}
-                onCreatePaymentRequest={onCreatePaymentRequest}
-                onPaymentRequestClicked={onPaymentRequestRowClicked}
-                onOpenPaymentPage={onOpenPaymentPage}
-                selectedPaymentRequestID={selectedPaymentRequestID}
-              />
+        {paymentRequestsExists && (
+          <LayoutWrapper className="lg:bg-white lg:min-h-[18rem] lg:py-10 lg:px-6  lg:rounded-lg">
+            <PaymentRequestTable
+              paymentRequests={localPaymentRequests}
+              pageSize={pageSize}
+              totalRecords={totalRecords}
+              onPageChanged={setPage}
+              setStatusSortDirection={setStatusSortDirection}
+              setCreatedSortDirection={setCreatedSortDirection}
+              setContactSortDirection={setContactSortDirection}
+              setAmountSortDirection={setAmountSortDirection}
+              onPaymentRequestDuplicateClicked={onDuplicatePaymentRequest}
+              onPaymentRequestDeleteClicked={onDeletePaymentRequest}
+              onPaymentRequestCopyLinkClicked={onCopyPaymentRequestLink}
+              isLoading={isLoadingPaymentRequests}
+              onCreatePaymentRequest={onCreatePaymentRequest}
+              onPaymentRequestClicked={onPaymentRequestRowClicked}
+              onOpenPaymentPage={onOpenPaymentPage}
+              selectedPaymentRequestID={selectedPaymentRequestID}
+            />
 
-              {!isInitialState && localPaymentRequests.length < totalRecords && (
-                <div className="flex">
-                  <Button
-                    variant="tertiary"
-                    size="big"
-                    onClick={fetchNextPage}
-                    disabled={isLoadingMore}
-                    className="lg:hidden mx-auto mt-6 mb-2 w-fit"
-                  >
-                    Show more
-                  </Button>
-                </div>
-              )}
-            </LayoutWrapper>
-          )}
-        </AnimatePresence>
+            {!isInitialState && localPaymentRequests.length < totalRecords && (
+              <div className="flex">
+                <Button
+                  variant="tertiary"
+                  size="big"
+                  onClick={fetchNextPage}
+                  disabled={isLoadingMore}
+                  className="lg:hidden mx-auto mt-6 mb-2 w-fit"
+                >
+                  Show more
+                </Button>
+              </div>
+            )}
+          </LayoutWrapper>
+        )}
 
         {/* Show loader until metrics are loaded which will determine whether we have any payment requests or not.*/}
         {isLoadingMetrics && (

--- a/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
+++ b/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
@@ -23,7 +23,7 @@ export interface PaymentRequestTableProps {
   setAmountSortDirection?: (sortDirection: SortDirection) => void
   onCreatePaymentRequest?: () => void
   onOpenPaymentPage: (paymentRequest: LocalPaymentRequest) => void
-  isLoading?: boolean // True when there are no payment requests at all, even when filters are not applied
+  isLoading?: boolean
   selectedPaymentRequestID?: string
 }
 

--- a/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
+++ b/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
@@ -225,7 +225,7 @@ const PaymentRequestTable = ({
 
       {/* Show empty state when contet has loaded and no there are no payment requests*/}
       {/* or also show when isEmpty property comes as `true` */}
-      {((!isLoading && paymentRequests && paymentRequests.length === 0) || isEmpty) && (
+      {!isLoading && paymentRequests && paymentRequests.length === 0 && !isEmpty && (
         // If `isEmpty` is true means that there're are no payment requests at all, no matter which tab is selected
         // Else,  there are no payment requests matching the filters
         <EmptyState

--- a/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
+++ b/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
@@ -23,8 +23,7 @@ export interface PaymentRequestTableProps {
   setAmountSortDirection?: (sortDirection: SortDirection) => void
   onCreatePaymentRequest?: () => void
   onOpenPaymentPage: (paymentRequest: LocalPaymentRequest) => void
-  isLoading?: boolean
-  isEmpty?: boolean // True when there are no payment requests at all, even when filters are not applied
+  isLoading?: boolean // True when there are no payment requests at all, even when filters are not applied
   selectedPaymentRequestID?: string
 }
 
@@ -44,7 +43,6 @@ const PaymentRequestTable = ({
   setContactSortDirection,
   setAmountSortDirection,
   isLoading = false,
-  isEmpty = false,
   onCreatePaymentRequest,
   onOpenPaymentPage,
   selectedPaymentRequestID,
@@ -224,14 +222,8 @@ const PaymentRequestTable = ({
       </div>
 
       {/* Show empty state when contet has loaded and no there are no payment requests*/}
-      {/* or also show when isEmpty property comes as `true` */}
-      {!isLoading && paymentRequests && paymentRequests.length === 0 && !isEmpty && (
-        // If `isEmpty` is true means that there're are no payment requests at all, no matter which tab is selected
-        // Else,  there are no payment requests matching the filters
-        <EmptyState
-          state={isEmpty ? 'empty' : 'nothingFound'}
-          onCreatePaymentRequest={onCreatePaymentRequest}
-        />
+      {!isLoading && paymentRequests && paymentRequests.length === 0 && (
+        <EmptyState state="nothingFound" onCreatePaymentRequest={onCreatePaymentRequest} />
       )}
       <Toaster positionY="top" positionX="right" duration={5000} />
     </>


### PR DESCRIPTION
The issue was that, we were showing skeleton even when there were no payment requests and then showing the empty state component. Andres's point is that, the user feels like something has gone wrong when it seems like the PR's were loading but ultimately failed to load.

The fix was to show the generic loader until we get the metrics which will determine if we have payment requests or not. Then we show the skeleton if there are payment requests, if not then we show the empty state component directly skipping the skeleton.

The skeleton might not be visible every time when there are payment requests because the lag between fetching metrics and fetching payment requests may not be long. If it is long, then the skeleton will be visible after loader. 
