### PR TITLE
[MOOV-2343]: Fixed visual glitch on payout tags

### DIFF
--- a/packages/components/src/components/functional/PayoutDetailsModal/PayoutDetailsModal.tsx
+++ b/packages/components/src/components/functional/PayoutDetailsModal/PayoutDetailsModal.tsx
@@ -169,9 +169,14 @@ const PayoutDetailsModal = ({
     }
   }
 
+  const onModalDismiss = () => {
+    setPayout(undefined)
+    onDismiss()
+  }
+
   return (
     <UIPayoutDetailsModal
-      onDismiss={onDismiss}
+      onDismiss={onModalDismiss}
       onTagAdded={onTagAdded}
       onTagCreated={onTagCreated}
       onTagRemoved={onTagRemoved}


### PR DESCRIPTION
When viewing the details of several different payouts, sometimes the _Add tag_ button would slide horizontally across the screen.