### PR TITLE
Fixed minor issue with card refund modal

### DIFF
--- a/packages/components/src/components/ui/CardRefundModal/CardRefundModal.tsx
+++ b/packages/components/src/components/ui/CardRefundModal/CardRefundModal.tsx
@@ -183,7 +183,7 @@ const CardRefundModal: React.FC<CardRefundModalProps> = ({
                       <Loader className="h-6 w-6 mx-auto" />
                     ) : (
                       <span>
-                        Confirm {!isVoid && <span>refund</span>}
+                        Confirm {!isCardVoid && <span>refund</span>}
                         {isCardVoid && <span>void</span>}
                       </span>
                     )}


### PR DESCRIPTION
Fixed minor issue with card refund modal where "refund" word was not visible in button.