### PR TITLE
Fix Display Issue for Long Customer Names/Emails in Payment Request Details Modal

### DIFF
--- a/packages/components/src/components/ui/Contact/Contact.tsx
+++ b/packages/components/src/components/ui/Contact/Contact.tsx
@@ -3,10 +3,22 @@ import { cva, VariantProps } from 'class-variance-authority'
 import { LocalContact } from '../../../types/LocalTypes'
 import { defaultAnonymousUserName } from '../../../utils/constants'
 
-const nameVariants = cva('truncate', {
+const containerVariant = cva('flex flex-col', {
   variants: {
     size: {
-      small: ['text-13px'],
+      small: [''],
+      large: ['pr-6'],
+    },
+  },
+  defaultVariants: {
+    size: 'small',
+  },
+})
+
+const nameVariants = cva('', {
+  variants: {
+    size: {
+      small: ['truncate text-13px'],
       large: ['text-[1.25rem]', 'font-semibold'],
     },
   },
@@ -15,10 +27,10 @@ const nameVariants = cva('truncate', {
   },
 })
 
-const emailVariants = cva('text-grey-text truncate', {
+const emailVariants = cva('text-grey-text break-all', {
   variants: {
     size: {
-      small: ['text-xs'],
+      small: ['text-xs truncate'],
       large: ['text-sm'],
     },
   },
@@ -33,9 +45,9 @@ export interface ContactProps extends LocalContact {
 
 const Contact = ({ name, email, size = 'small' }: ContactProps) => {
   return (
-    <div className="flex flex-col">
-      <span className={nameVariants({ size: size })}>{name ?? defaultAnonymousUserName}</span>
-      {email && <span className={emailVariants({ size: size })}>{email}</span>}
+    <div className={containerVariant({ size })}>
+      <p className={nameVariants({ size })}>{name ?? defaultAnonymousUserName}</p>
+      {email && <p className={emailVariants({ size })}>{email}</p>}
     </div>
   )
 }

--- a/packages/components/src/components/ui/Contact/Contact.tsx
+++ b/packages/components/src/components/ui/Contact/Contact.tsx
@@ -19,7 +19,7 @@ const nameVariants = cva('', {
   variants: {
     size: {
       small: ['truncate text-13px'],
-      large: ['text-[1.25rem]', 'font-semibold'],
+      large: ['text-[1.25rem]', 'font-semibold', 'leading-7', 'mb-2'],
     },
   },
   defaultVariants: {

--- a/packages/components/src/components/ui/PaymentRequestDetails/PaymentRequestDetails.tsx
+++ b/packages/components/src/components/ui/PaymentRequestDetails/PaymentRequestDetails.tsx
@@ -35,13 +35,14 @@ const PaymentRequestDetails = ({
   return (
     <>
       <div className="bg-[#F6F9F9] px-6 lg:pl-8 lg:pr-7 relative mb-[4.875rem]">
-        <div className="flex justify-between pb-[2.625rem] pt-6 items-center">
+        <div className="flex justify-between pb-[2.625rem] pt-6">
           <Contact
             name={paymentRequest.contact.name}
             email={paymentRequest.contact.email}
             size="large"
-          ></Contact>
-          <QRCode url={hostedPaymentLink}></QRCode>
+          />
+
+          <QRCode url={hostedPaymentLink} />
         </div>
         <div className="absolute left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-opacity-100 w-[92%]">
           <CopyLink link={hostedPaymentLink}></CopyLink>

--- a/packages/components/src/components/ui/QRCode/QRCode.tsx
+++ b/packages/components/src/components/ui/QRCode/QRCode.tsx
@@ -2,9 +2,15 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { useRef, useState } from 'react'
 import QRCodeComponent from 'react-qr-code'
 
+import { cn } from '../../../utils'
 import { Icon, Sheet, SheetContent } from '../atoms'
 
-const QRCode = ({ url }: { url: string }) => {
+interface QRCodeProps {
+  url: string
+  className?: string
+}
+
+const QRCode: React.FC<QRCodeProps> = ({ url, className }) => {
   const [isHovered, setIsHovered] = useState(false)
   const [isQrModalOpen, setIsQrModalOpen] = useState(false)
   const largeQrCodeCanvasRef = useRef<HTMLCanvasElement>(null)
@@ -65,7 +71,7 @@ const QRCode = ({ url }: { url: string }) => {
       <canvas ref={largeQrCodeCanvasRef} height="1024" width="1024" className="hidden"></canvas>
 
       <div
-        className="w-14 lg:w-20 lg:h-20 relative"
+        className={cn('w-14 min-w-[3.5rem] lg:min-w-[5rem] lg:w-20 lg:h-20 relative', className)}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >


### PR DESCRIPTION
This pull request addresses a UI issue in the Payment Request Details modal. Previously, long customer names or emails would cause the QR code to be compressed, rendering it nearly illegible. With this fix, long customer names and emails are now displayed appropriately without affecting the QR code's size or readability.