### PR TITLE
Adjust Button Sizes and Naming Conventions

### DIFF
--- a/packages/components/src/components/functional/CreatePayoutModal/CreatePayoutModal.tsx
+++ b/packages/components/src/components/functional/CreatePayoutModal/CreatePayoutModal.tsx
@@ -106,7 +106,7 @@ const CreatePayoutModal = ({
       {payoutID && (
         <PayoutAuthoriseForm
           id={payoutID}
-          size="medium"
+          size="x-small"
           formRef={approveFormRef}
           className="hidden"
         />

--- a/packages/components/src/components/functional/CreatePayoutModal/CreatePayoutModal.tsx
+++ b/packages/components/src/components/functional/CreatePayoutModal/CreatePayoutModal.tsx
@@ -106,7 +106,7 @@ const CreatePayoutModal = ({
       {payoutID && (
         <PayoutAuthoriseForm
           id={payoutID}
-          size="x-small"
+          size="medium"
           formRef={approveFormRef}
           className="hidden"
         />

--- a/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -518,7 +518,7 @@ const PaymentRequestDashboardMain = ({
         </span>
         <div>
           <Button
-            size="big"
+            size="large"
             onClick={onCreatePaymentRequest}
             className="w-10 h-10 md:w-full md:h-full"
           >
@@ -631,7 +631,7 @@ const PaymentRequestDashboardMain = ({
         <div className="flex">
           <Button
             variant="tertiary"
-            size="big"
+            size="large"
             onClick={fetchNextPage}
             disabled={isLoadingMore}
             className="lg:hidden mx-auto mt-6 mb-2 w-fit"

--- a/packages/components/src/components/ui/Account/CurrentAccountsHeader/CurrentAccountsHeader.tsx
+++ b/packages/components/src/components/ui/Account/CurrentAccountsHeader/CurrentAccountsHeader.tsx
@@ -10,7 +10,7 @@ const CurrentAccountsHeader = ({ onCreatePaymentAccount }: CurrentAccountsHeader
       <span className="leading-8 font-medium text-2xl md:text-[1.75rem]">Current accounts</span>
       <div className="w-[172px]">
         {onCreatePaymentAccount && (
-          <Button size="big" onClick={onCreatePaymentAccount} variant="secondary">
+          <Button size="large" onClick={onCreatePaymentAccount} variant="secondary">
             <Icon name="add/16" className="text-default-text" />
             <span className="pl-2 md:inline-block">New Account</span>
           </Button>

--- a/packages/components/src/components/ui/Account/CurrentAccountsList/CurrentAcountsList.tsx
+++ b/packages/components/src/components/ui/Account/CurrentAccountsList/CurrentAcountsList.tsx
@@ -107,12 +107,13 @@ const CurrentAcountsList = ({
       {/* External accounts list */}
       {externalAccounts && externalAccounts.length > 0 && (
         <div>
-          <div className="flex ml-3 mb-16">
+          <div className="flex ml-3 mb-16 items-center">
             <span className="leading-8 font-medium text-2xl md:text-[1.75rem]">
               Connected accounts
             </span>
             <Button
               variant={'secondary'}
+              size="medium"
               className="h-fit w-fit ml-auto"
               onClick={handleOnConnectClicked}
             >

--- a/packages/components/src/components/ui/Account/External/ExternalAccountConnectCard.tsx
+++ b/packages/components/src/components/ui/Account/External/ExternalAccountConnectCard.tsx
@@ -31,7 +31,7 @@ const ExternalAccountConnectCard = ({
       <div className="flex flex-row mt-7">
         <Button
           variant="primary"
-          size="big"
+          size="large"
           className="w-fit"
           onClick={onConnectClicked}
           disabled={disabled}

--- a/packages/components/src/components/ui/BankRefundModal/BankRefundModal.tsx
+++ b/packages/components/src/components/ui/BankRefundModal/BankRefundModal.tsx
@@ -202,7 +202,7 @@ const BankRefundModal: React.FC<BankRefundModalProps> = ({
                 <div className="lg:mt-14 lg:static lg:p-0 fixed bottom-16 left-0 w-full px-6 mx-auto pb-4 z-20">
                   <Button
                     variant="primaryDark"
-                    size="big"
+                    size="large"
                     className="disabled:!bg-grey-text disabled:!opacity-100 disabled:cursor-not-allowed"
                     onClick={onRefundClick}
                     disabled={isRefundButtonDisabled}

--- a/packages/components/src/components/ui/CaptureModal/CaptureModal.tsx
+++ b/packages/components/src/components/ui/CaptureModal/CaptureModal.tsx
@@ -143,7 +143,7 @@ const CaptureModal: React.FC<CaptureModalProps> = ({
                 <div className="lg:mt-14 lg:static lg:p-0 fixed bottom-16 left-0 w-full px-6 mx-auto pb-4 z-20">
                   <Button
                     variant="primaryDark"
-                    size="big"
+                    size="large"
                     className={cn({
                       '!bg-grey-text disabled:!opacity-100 cursor-not-allowed':
                         isCaptureButtonDisabled,

--- a/packages/components/src/components/ui/CardRefundModal/CardRefundModal.tsx
+++ b/packages/components/src/components/ui/CardRefundModal/CardRefundModal.tsx
@@ -174,7 +174,7 @@ const CardRefundModal: React.FC<CardRefundModalProps> = ({
                 <div className="lg:mt-14 lg:static lg:p-0 fixed bottom-16 left-0 w-full px-6 mx-auto pb-4 z-20">
                   <Button
                     variant="primaryDark"
-                    size="big"
+                    size="large"
                     className="disabled:!bg-grey-text disabled:!opacity-100 disabled:cursor-not-allowed"
                     onClick={onCardRefundConfirm}
                     disabled={isRefundButtonDisabled}

--- a/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
+++ b/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
@@ -709,7 +709,7 @@ const CreatePaymentRequestPage = ({
                         )}
                         <Button
                           variant={isSubmitting ? 'text' : 'primaryDark'}
-                          size="big"
+                          size="large"
                           onClick={onConfirmClicked}
                           disabled={isSubmitting}
                           className="disabled:!opacity-100 disabled:!bg-grey-text"
@@ -724,7 +724,7 @@ const CreatePaymentRequestPage = ({
                         {/* Edit button */}
                         <Button
                           variant="secondary"
-                          size="big"
+                          size="large"
                           onClick={() => setIsReviewing(false)}
                         >
                           Edit
@@ -981,7 +981,7 @@ const CreatePaymentRequestPage = ({
                                 >
                                   <Button
                                     variant="secondary"
-                                    size="big"
+                                    size="large"
                                     onClick={onReviewClicked}
                                     nextArrow
                                   >

--- a/packages/components/src/components/ui/CreatePayoutModal/CreatePayoutModal.tsx
+++ b/packages/components/src/components/ui/CreatePayoutModal/CreatePayoutModal.tsx
@@ -629,7 +629,7 @@ const CreatePayoutModal: React.FC<CreatePayoutModalProps> = ({
                   </div>
                   <Button
                     variant="primaryDark"
-                    size="big"
+                    size="large"
                     className="disabled:!bg-grey-text disabled:!opacity-100 disabled:cursor-not-allowed"
                     onClick={() => onCreatePayoutClick(true)}
                     disabled={isCreateAndApproveButtonDisabled}
@@ -642,7 +642,7 @@ const CreatePayoutModal: React.FC<CreatePayoutModalProps> = ({
                   </Button>
                   <Button
                     variant="secondary"
-                    size="big"
+                    size="large"
                     className="disabled:!bg-grey-text disabled:!opacity-100 disabled:cursor-not-allowed mt-4"
                     onClick={() => onCreatePayoutClick(false)}
                     disabled={isCreatePayoutButtonDisabled}

--- a/packages/components/src/components/ui/CustomModal/CustomModal.tsx
+++ b/packages/components/src/components/ui/CustomModal/CustomModal.tsx
@@ -36,7 +36,7 @@ const CustomModal = ({
   buttonRowClassName,
   showDefault = true,
   buttonText = 'Apply',
-  buttonClaseName = 'w-full md:w-auto px-16 ml-auto',
+  buttonClaseName = 'w-full md:w-[10.625rem] px-16 ml-auto',
 }: CustomModalProps) => {
   const [isDefaultChecked, setIsDefaultChecked] = useState<boolean>(false)
   const [currentState, setCurrentState] = useState<CustomModalState>()
@@ -113,7 +113,7 @@ const CustomModal = ({
 
                     <Button
                       variant="primaryDark"
-                      size="medium"
+                      size="large"
                       onClick={onApplyClicked}
                       disabled={!onApplyEnabled}
                       className={buttonClaseName}

--- a/packages/components/src/components/ui/InviteUserModal/InviteUserModal.tsx
+++ b/packages/components/src/components/ui/InviteUserModal/InviteUserModal.tsx
@@ -105,7 +105,7 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({
                   </div>
                   <Button
                     variant="primaryDark"
-                    size="big"
+                    size="large"
                     className="mt-4 disabled:!bg-grey-text disabled:!opacity-100 disabled:cursor-not-allowed lg:w-[10.25rem]"
                     onClick={() => onInviteClick()}
                     disabled={isInviteButtonDisabled}

--- a/packages/components/src/components/ui/PaymentRequestTable/EmptyState.tsx
+++ b/packages/components/src/components/ui/PaymentRequestTable/EmptyState.tsx
@@ -31,7 +31,7 @@ const EmptyState: React.FC<EmptyStateProps> = ({
       <p className="text-sm/4 text-grey-text">{customDesc ? customDesc : description}</p>
 
       {state === 'empty' && onCreatePaymentRequest && (
-        <Button size="big" onClick={onCreatePaymentRequest} className="mt-[2.625rem] w-64">
+        <Button size="large" onClick={onCreatePaymentRequest} className="mt-[2.625rem] w-64">
           Create payment request
         </Button>
       )}

--- a/packages/components/src/components/ui/atoms/Button/Button.tsx
+++ b/packages/components/src/components/ui/atoms/Button/Button.tsx
@@ -55,15 +55,15 @@ export const buttonVariants = cva(
         ],
       },
       size: {
-        big: ['text-base', 'px-3', 'py-3', 'md:px-6'],
-        medium: ['text-sm', 'px-4', 'py-2'],
+        large: ['text-base', 'px-3', 'py-3', 'md:px-6'],
+        medium: ['text-sm', 'px-4', 'py-2', 'leading-6'],
         small: ['text-[0.813rem]', 'py-1', 'px-3'],
-        'x-small': ['text-[0.813rem]', 'py-1', 'px-3'],
+        'x-small': ['text-[0.813rem]', 'py-1', 'px-3', 'leading-4'],
       },
     },
     defaultVariants: {
       variant: 'primary',
-      size: 'big',
+      size: 'large',
     },
   },
 )
@@ -87,14 +87,14 @@ const icon = cva('w-full h-full', {
 const iconContainer = cva('', {
   variants: {
     size: {
-      big: ['w-4', 'h-4'],
+      large: ['w-4', 'h-4'],
       medium: ['w-4', 'h-4'],
       small: ['w-4', 'h-4'],
       'x-small': ['w-3', 'h-3'],
     },
   },
   defaultVariants: {
-    size: 'big',
+    size: 'large',
   },
 })
 

--- a/packages/components/src/components/ui/pages/PayoutDashboard/PayoutDashboard.tsx
+++ b/packages/components/src/components/ui/pages/PayoutDashboard/PayoutDashboard.tsx
@@ -128,7 +128,7 @@ const PayoutDashboard: React.FC<PayoutDashboardProps> = ({
                   <LayoutWrapper layout={'preserve-aspect'}>
                     <Button
                       variant={'secondary'}
-                      size="big"
+                      size="large"
                       onClick={handleApproveBatchPayouts}
                       className="space-x-2 w-fit h-10 md:w-full md:h-full transition-all ease-in-out duration-200 disabled:!bg-grey-text disabled:!opacity-100 disabled:cursor-not-allowed"
                       disabled={isApproveButtonDisabled}
@@ -148,7 +148,7 @@ const PayoutDashboard: React.FC<PayoutDashboardProps> = ({
                 )}
               </AnimatePresence>
             </div>
-            <Button size="big" onClick={onCreatePayout} className="w-10 h-10 md:w-full md:h-full">
+            <Button size="large" onClick={onCreatePayout} className="w-10 h-10 md:w-full md:h-full">
               <span className="hidden md:inline-block">Create payout</span>
               <Icon name="add/16" className="md:hidden" />
             </Button>

--- a/packages/components/src/components/ui/pages/UserDashboard/UserDashboard.tsx
+++ b/packages/components/src/components/ui/pages/UserDashboard/UserDashboard.tsx
@@ -50,7 +50,7 @@ const UserDashboard: React.FC<UserDashboardProps> = ({
         <div className="flex gap-8 justify-between items-center mb-8 md:mb-[68px] md:px-4">
           <span className="leading-8 font-medium text-2xl md:text-[1.75rem]">Users</span>
           <div className="flex">
-            <Button size="big" onClick={onInviteUser} className="w-10 h-10 md:w-full md:h-full">
+            <Button size="large" onClick={onInviteUser} className="w-10 h-10 md:w-full md:h-full">
               <span className="hidden md:inline-block">Invite user</span>
               <Icon name="add/16" className="md:hidden" />
             </Button>


### PR DESCRIPTION
This pull request addresses the button sizes and naming conventions to align them with the design specifications.

Changes include:

1. Corrected the size of the "x-small" buttons, which were previously too large.
2. Renamed button sizing from "big" to "large" to match design nomenclature.

Important notes:

- A few other button size corrections were made. Please ensure that all buttons throughout the portal appear as expected.

Specific areas for review:

- **Payment Request Details - Transactions**: Adjusted action buttons such as "capture", "void", and "refund" to be smaller, aligning with the design specifications.
- **Custom Modal**: Updated the primary button (typically labeled "Apply") from "medium" to "large" to comply with design specifications.
- **Connect Account**: Modified the connect account button from "large" to "medium" as per design.