### PR TITLE
Remove "Type" Column for Connected Accounts

### DIFF
--- a/packages/components/src/components/ui/organisms/TransactionsTable/TransactionsTable.tsx
+++ b/packages/components/src/components/ui/organisms/TransactionsTable/TransactionsTable.tsx
@@ -23,6 +23,7 @@ export interface TransactionsTableProps extends React.HTMLAttributes<HTMLDivElem
   pagination: Pick<Pagination, 'pageSize' | 'totalSize'>
   onPageChange: (page: number) => void
   onSort: (name: 'date' | 'amount', direction: SortDirection) => void
+  isShowingConnectedAccount?: boolean
   isLoading?: boolean
 }
 
@@ -32,6 +33,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
   onPageChange,
   onSort,
   isLoading,
+  isShowingConnectedAccount = false,
   ...props
 }) => {
   const renderBasicInfoLayout = (
@@ -72,9 +74,11 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
                 <TableHead className="w-[300px]">
                   <ColumnHeader label={'Description'} />
                 </TableHead>
-                <TableHead>
-                  <ColumnHeader label={'Type'} />
-                </TableHead>
+                {!isShowingConnectedAccount && (
+                  <TableHead>
+                    <ColumnHeader label={'Type'} />
+                  </TableHead>
+                )}
                 <TableHead>{/* Export  Icon + Status */}</TableHead>
               </TableRow>
             </TableHeader>
@@ -162,9 +166,11 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
                     <TableCell>
                       <div className="truncate w-56">{transaction.description}</div>
                     </TableCell>
-                    <TableCell>
-                      <div className="truncate w-36">{transaction.type}</div>
-                    </TableCell>
+                    {!isShowingConnectedAccount && (
+                      <TableCell>
+                        <div className="truncate w-36">{transaction.type}</div>
+                      </TableCell>
+                    )}
 
                     {/* Fill empty space */}
                     <TableCell className="p-0"></TableCell>

--- a/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
@@ -194,6 +194,7 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
           onPageChange={onPageChange}
           onSort={onSort}
           isLoading={isLoadingTransactions}
+          isShowingConnectedAccount={account?.isConnectedAccount}
         />
       </div>
 


### PR DESCRIPTION
In this update, the "Type" column indicating the network has been removed exclusively for connected accounts, given the unavailability of that information. It's important to note that the "Type" column will still be displayed for regular (non-connected) accounts.

Here's a visual comparison of the changes made for a connected account:
| Before | After |
|--------|--------|
| <img width="1624" alt="Before" src="https://github.com/nofrixion/nofrixion.business/assets/52673485/f2b8d939-2aff-4dbd-843d-c9660f546f00"> | <img width="1624" alt="After" src="https://github.com/nofrixion/nofrixion.business/assets/52673485/c14194d0-c3fd-4844-8f2c-918ad5dd2f20"> | 