### PR TITLE
Remove Payout Description Validation in Creation Modal

### DIFF
--- a/packages/components/src/components/ui/CreatePayoutModal/CreatePayoutModal.tsx
+++ b/packages/components/src/components/ui/CreatePayoutModal/CreatePayoutModal.tsx
@@ -615,9 +615,7 @@ const CreatePayoutModal: React.FC<CreatePayoutModalProps> = ({
                         maxLength={140}
                         value={description ?? ''}
                         onChange={(e) => setDescription(e.target.value)}
-                        validation={onValidateYourReference}
                         subText="For internal use only."
-                        enableQuickValidation
                       />
                     </div>
                   </div>


### PR DESCRIPTION
The PR removes the validation for the payout description in the `CreatePayoutModal` component. This change simplifies the user input process and removes unnecessary restrictions.