### PR TITLE
Add Account Graphic (Chart) UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
     },
     "apps/business": {
       "name": "nofrixion-business",
-      "version": "0.1.17",
+      "version": "0.1.19",
       "dependencies": {
         "@nofrixion/components": "*",
         "@nofrixion/moneymoov": "*",
@@ -6308,6 +6308,60 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.9.tgz",
+      "integrity": "sha512-mZowFN3p64ajCJJ4riVYlOjNlBJv3hctgAY01pjw3qTnJePD8s9DZmYDzhHKvzfCYvdjwylkU38+Vdt7Cu2FDA=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.2.tgz",
+      "integrity": "sha512-At+Ski7dL8Bs58E8g8vPcFJc8tGcaC12Z4m07+p41+DRqnZQcAlp3NfYjLrhNYv+zEyQitU1CUxXNjqUyf+c0g=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-VZofjpEt8HWv3nxUAosj5o/+4JflnJ7Bbv07k17VO3T2WRuzGdZeookfaF60iVh5RdhVG49LE5w6LIshVUC6rg=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.3.tgz",
+      "integrity": "sha512-6OZ2EIB4lLj+8cUY7I/Cgn9Q+hLdA4DjJHYOQDiHL0SzqS1K9DL5xIOVBSIHgF+tiuO9MU1D36qvdIvRDRPh+Q==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.1.tgz",
+      "integrity": "sha512-blRhp7ki7pVznM8k6lk5iUU9paDbVRVq+/xpf0RRgSJn5gr6SE7RcFtxooYGMBOc1RZiGyqRpVdu5AD0z0ooMA=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.6.tgz",
+      "integrity": "sha512-lo3oMLSiqsQUovv8j15X4BNEDOsnHuGjeVg7GRbAuB2PUa1prK5BNSOu6xixgNf3nqxPl4I1BqJWrPvFGlQoGQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.4.tgz",
+      "integrity": "sha512-M2/xsWPsjaZc5ifMKp1EBp0gqJG0eO/zlldJNOC85Y/5DGsBQ49gDkRJ2h5GY7ZVD6KUumvZWsylSbvTaJTqKg==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.2.tgz",
+      "integrity": "sha512-kbdRXTmUgNfw5OTE3KZnFQn6XdIc4QGroN5UixgdrXATmYsdlPQS6pEut9tVlIojtzuFD4txs/L+Rq41AHtLpg=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-GGTvzKccVEhxmRfJEB6zhY9ieT4UhGVUIQaBzFpUO9OXy2ycAlnPCSJLzmGGgqt3KVjqN3QCQB4g1rsZnHsWhg=="
+    },
     "node_modules/@types/detect-port": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@types/detect-port/-/detect-port-1.3.3.tgz",
@@ -8942,6 +8996,116 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -8988,6 +9152,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/deep-equal": {
       "version": "2.2.2",
@@ -9258,6 +9427,14 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.0.3",
@@ -10194,6 +10371,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -10357,6 +10539,14 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-equals": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -11497,6 +11687,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/invariant": {
@@ -15042,6 +15240,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "node_modules/react-multi-date-picker": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/react-multi-date-picker/-/react-multi-date-picker-3.3.4.tgz",
@@ -15126,6 +15329,18 @@
         }
       }
     },
+    "node_modules/react-resize-detector": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.1.0.tgz",
+      "integrity": "sha512-S7szxlaIuiy5UqLhLL1KY3aoyGHbZzsTpYal9eYMwCyKqoqoVLCmIgAgNyIM1FhnP2KyBygASJxdhejrzjMb+w==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.14.2.tgz",
@@ -15162,6 +15377,20 @@
       "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
       "peerDependencies": {
         "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-2.0.5.tgz",
+      "integrity": "sha512-BMP2Ad42tD60h0JW6BFaib+RJuV5dsXJK9Baxiv/HlNFjvRLqA9xrNKxVWnUIZPQfzUwGXIlU/dSYLU+54YGQA==",
+      "dependencies": {
+        "fast-equals": "^5.0.0",
+        "react-transition-group": "2.9.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-style-singleton": {
@@ -15228,6 +15457,21 @@
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "dependencies": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0",
+        "react-dom": ">=15.0.0"
       }
     },
     "node_modules/react-use-measure": {
@@ -15402,6 +15646,43 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.9.0.tgz",
+      "integrity": "sha512-cVgiAU3W5UrA8nRRV/N0JrudgZzY/vjkzrlShbH+EFo1vs4nMlXgshZWLI0DfDLmn4/p4pF7Lq7F5PU+K94Ipg==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.19",
+        "react-is": "^16.10.2",
+        "react-resize-detector": "^8.0.4",
+        "react-smooth": "^2.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -18156,6 +18437,27 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "36.6.11",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.6.11.tgz",
+      "integrity": "sha512-nT8kCiJp8dQh8g991J/R5w5eE2KnO8EAIP0xocWlh9l2okngMWglOPoMZzJvek8Q1KUc4XE/mJxTZnvOB1sTYg==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vite": {
       "version": "4.4.9",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
@@ -18955,6 +19257,7 @@
         "react-text-mask": "^5.5.0",
         "react-toastify": "^9.1.2",
         "react-use-measure": "^2.1.1",
+        "recharts": "^2.9.0",
         "tailwind-merge": "^1.14.0",
         "tailwindcss-animate": "^1.0.6",
         "text-mask-addons": "^3.8.0",
@@ -19184,7 +19487,7 @@
     },
     "packages/web-components": {
       "name": "@nofrixion/webcomponents",
-      "version": "0.1.17",
+      "version": "0.1.19",
       "dependencies": {
         "@headlessui/react": "1.6.0",
         "@nofrixion/components": "*",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,6 +47,7 @@
     "react-text-mask": "^5.5.0",
     "react-toastify": "^9.1.2",
     "react-use-measure": "^2.1.1",
+    "recharts": "^2.9.0",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.6",
     "text-mask-addons": "^3.8.0",

--- a/packages/components/src/components/ui/molecules/Chart/AccountChart.stories.tsx
+++ b/packages/components/src/components/ui/molecules/Chart/AccountChart.stories.tsx
@@ -1,0 +1,54 @@
+import { Currency } from '@nofrixion/moneymoov'
+import { Meta, StoryFn } from '@storybook/react'
+
+import Chart, { ChartPoint } from './AccountChart'
+
+export default {
+  title: 'Molecules/Account Chart',
+  component: Chart,
+} as Meta
+
+const data: ChartPoint[] = [
+  {
+    x: new Date(2021, 2, 1),
+    y: 24267,
+  },
+  {
+    x: new Date(2021, 3, 1),
+    y: 52150,
+  },
+  {
+    x: new Date(2021, 4, 1),
+    y: 28000,
+  },
+  {
+    x: new Date(2021, 5, 1),
+    y: 56000,
+  },
+  {
+    x: new Date(2021, 6, 1),
+    y: 64000,
+  },
+  {
+    x: new Date(2021, 7, 1),
+    y: 75000,
+  },
+  {
+    x: new Date(2021, 8, 1),
+    y: 70000,
+  },
+]
+
+const Template: StoryFn<typeof Chart> = (args) => {
+  return (
+    <div className="h-28">
+      <Chart {...args} />
+    </div>
+  )
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  points: data,
+  currency: Currency.EUR,
+}

--- a/packages/components/src/components/ui/molecules/Chart/AccountChart.stories.tsx
+++ b/packages/components/src/components/ui/molecules/Chart/AccountChart.stories.tsx
@@ -6,6 +6,12 @@ import Chart, { ChartPoint } from './AccountChart'
 export default {
   title: 'Molecules/Account Chart',
   component: Chart,
+  argTypes: {
+    currency: {
+      options: Object.values(Currency),
+      control: { type: 'select' },
+    },
+  },
 } as Meta
 
 const data: ChartPoint[] = [

--- a/packages/components/src/components/ui/molecules/Chart/AccountChart.tsx
+++ b/packages/components/src/components/ui/molecules/Chart/AccountChart.tsx
@@ -1,5 +1,6 @@
 import { Currency } from '@nofrixion/moneymoov'
 import { format } from 'date-fns'
+import { useState } from 'react'
 import { Area, AreaChart, ResponsiveContainer, Tooltip } from 'recharts'
 
 import { formatAmount } from '../../../../utils/formatters'
@@ -16,6 +17,8 @@ export interface AccountChartProps {
 }
 
 const Chart: React.FC<AccountChartProps> = ({ points, currency }) => {
+  const [hovered, setHovered] = useState(false)
+
   const formatData = (points: ChartPoint[]) => {
     return points.map((point) => {
       return {
@@ -58,6 +61,8 @@ const Chart: React.FC<AccountChartProps> = ({ points, currency }) => {
           left: 0,
           bottom: 0,
         }}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
       >
         <Tooltip
           cursor={{ stroke: '#00264D', strokeWidth: 2 }}
@@ -69,6 +74,7 @@ const Chart: React.FC<AccountChartProps> = ({ points, currency }) => {
           stroke="#009999"
           strokeWidth={2}
           fill="#40BFBF"
+          fillOpacity={hovered ? 0.3 : 0.2}
           activeDot={{ stroke: '#00264D', fill: '#00264D', strokeWidth: 2, r: 2 }}
         />
       </AreaChart>

--- a/packages/components/src/components/ui/molecules/Chart/AccountChart.tsx
+++ b/packages/components/src/components/ui/molecules/Chart/AccountChart.tsx
@@ -1,0 +1,79 @@
+import { Currency } from '@nofrixion/moneymoov'
+import { format } from 'date-fns'
+import { Area, AreaChart, ResponsiveContainer, Tooltip } from 'recharts'
+
+import { formatAmount } from '../../../../utils/formatters'
+import { formatCurrency } from '../../../../utils/uiFormaters'
+
+export interface ChartPoint {
+  x: Date
+  y: number
+}
+
+export interface AccountChartProps {
+  points: ChartPoint[]
+  currency: Currency
+}
+
+const Chart: React.FC<AccountChartProps> = ({ points, currency }) => {
+  const formatData = (points: ChartPoint[]) => {
+    return points.map((point) => {
+      return {
+        x: format(point.x, 'MMM dd, yyyy'),
+        y: point.y,
+      }
+    })
+  }
+
+  const CustomTooltip = ({
+    active,
+    payload,
+    currency,
+  }: {
+    active?: boolean
+    payload?: any
+    currency: Currency
+  }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white rounded shadow-small py-1 px-2 text-center">
+          <p className="text-[10px]/4 text-grey-text">{payload[0].payload.x}</p>
+          <p className="text-sm/4 text-default-text font-semibold">
+            {formatCurrency(currency)} {formatAmount(payload[0].payload.y)}
+          </p>
+        </div>
+      )
+    }
+
+    return null
+  }
+
+  return (
+    <ResponsiveContainer className="w-full h-full">
+      <AreaChart
+        data={formatData(points)}
+        margin={{
+          top: 10,
+          right: 30,
+          left: 0,
+          bottom: 0,
+        }}
+      >
+        <Tooltip
+          cursor={{ stroke: '#00264D', strokeWidth: 2 }}
+          content={(props) => <CustomTooltip {...props} currency={currency} />}
+        />
+        <Area
+          type="linear"
+          dataKey="y"
+          stroke="#009999"
+          strokeWidth={2}
+          fill="#40BFBF"
+          activeDot={{ stroke: '#00264D', fill: '#00264D', strokeWidth: 2, r: 2 }}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  )
+}
+
+export default Chart


### PR DESCRIPTION
This pull request introduces a new component - the Account Graphic (Chart)UI.

You can test this component in Storybook under "[Molecules/Account Chart](https://64d9fa344203198b9ba80047-rwzqtffbab.chromatic.com/?path=/story/molecules-account-chart--default)" Additionally, you have the flexibility to manipulate the chart's data by adjusting the `points` and `currency` props.

Demo video showing how to do so:

https://github.com/nofrixion/nofrixion.business/assets/52673485/48912fc1-7b51-4b55-9c36-afe1ef9e86a2

