### PR TITLE
[MOOV-2305]: Added possibility to archive payment requests

### DIFF
--- a/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
+++ b/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
@@ -1,4 +1,4 @@
-import { PaymentResult } from "@nofrixion/moneymoov";
+import { PaymentResult } from '@nofrixion/moneymoov'
 import classNames from 'classnames'
 
 import { LocalPaymentRequest } from '../../../types/LocalTypes'
@@ -194,8 +194,8 @@ const PaymentRequestTable = ({
                   onDelete={
                     paymentRequest.remoteStatus === PaymentResult.None
                       ? () =>
-                        onPaymentRequestDeleteClicked &&
-                        onPaymentRequestDeleteClicked(paymentRequest)
+                          onPaymentRequestDeleteClicked &&
+                          onPaymentRequestDeleteClicked(paymentRequest)
                       : undefined
                   }
                   onCopyLink={() =>

--- a/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
+++ b/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
@@ -1,3 +1,4 @@
+import { PaymentResult } from "@nofrixion/moneymoov";
 import classNames from 'classnames'
 
 import { LocalPaymentRequest } from '../../../types/LocalTypes'
@@ -191,11 +192,11 @@ const PaymentRequestTable = ({
                     onPaymentRequestDuplicateClicked(paymentRequest)
                   }
                   onDelete={
-                    paymentRequest.paymentAttempts && paymentRequest.paymentAttempts.length > 0
-                      ? undefined
-                      : () =>
-                          onPaymentRequestDeleteClicked &&
-                          onPaymentRequestDeleteClicked(paymentRequest)
+                    paymentRequest.remoteStatus === PaymentResult.None
+                      ? () =>
+                        onPaymentRequestDeleteClicked &&
+                        onPaymentRequestDeleteClicked(paymentRequest)
+                      : undefined
                   }
                   onCopyLink={() =>
                     onPaymentRequestCopyLinkClicked &&

--- a/packages/components/src/types/LocalTypes.ts
+++ b/packages/components/src/types/LocalTypes.ts
@@ -1,4 +1,4 @@
-import { Currency, PayoutStatus } from '@nofrixion/moneymoov'
+import { Currency, PaymentResult, PayoutStatus } from '@nofrixion/moneymoov'
 
 import {
   FieldID,
@@ -45,6 +45,7 @@ export interface LocalPaymentRequest {
   customerName?: string
   createdByUser?: LocalUser
   merchantTokenDescription?: string
+  remoteStatus: PaymentResult
 }
 
 export interface LocalCounterparty {

--- a/packages/components/src/utils/parsers.ts
+++ b/packages/components/src/utils/parsers.ts
@@ -415,6 +415,7 @@ const remotePaymentRequestToLocalPaymentRequest = (
       ? parseApiUserToLocalUser(remotePaymentRequest.createdByUser)
       : undefined,
     merchantTokenDescription: remotePaymentRequest.merchantTokenDescription,
+    remoteStatus: remotePaymentRequest.status,
   }
 }
 


### PR DESCRIPTION
Updated the Delete Payment Request button logic to enable deletion of payment requests with events and status 'None', which will archive the record rather than delete it.

**Note:** Depends on MoneyMoovAPI PR #1322 to work.