### PR TITLE
Ensure build compatibility for account list and transactions (web-components)

### DIFF
--- a/packages/components/src/components/functional/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/functional/AccountDashboard/AccountDashboard.tsx
@@ -11,7 +11,7 @@ import {
   useTransactions,
   useUpdateAccountName,
 } from '@nofrixion/moneymoov'
-import { QueryClientProvider, useQueryClient } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query'
 import { add, endOfDay, startOfDay } from 'date-fns'
 import { useEffect, useState } from 'react'
 
@@ -21,12 +21,15 @@ import { DateRange } from '../../ui/DateRangePicker/DateRangePicker'
 import { AccountDashboard as UIAccountDashboard } from '../../ui/pages/AccountDashboard/AccountDashboard'
 import { makeToast } from '../../ui/Toast/Toast'
 
+const queryClient = new QueryClient()
+
 export interface AccountDashboardProps {
   token?: string // Example: "eyJhbGciOiJIUz..."
   onAllCurrentAccountsClick?: () => void
   accountId: string // Example: "bf9e1828-c6a1-4cc5-a012-08daf2ff1b2d"
   apiUrl: string // Example: "https://api.nofrixion.com/api/v1"
   merchantId: string
+  isWebComponent?: boolean
 }
 
 const AccountDashboard = ({
@@ -35,10 +38,12 @@ const AccountDashboard = ({
   onAllCurrentAccountsClick,
   apiUrl = 'https://api.nofrixion.com/api/v1',
   merchantId,
+  isWebComponent,
 }: AccountDashboardProps) => {
-  const queryClient = useQueryClient()
+  const queryClientToUse = isWebComponent ? queryClient : useQueryClient()
+
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClientToUse}>
       <AccountDashboardMain
         token={token}
         accountId={accountId}

--- a/packages/components/src/components/functional/CurrentAccountsList/CurrentAccountsList.tsx
+++ b/packages/components/src/components/functional/CurrentAccountsList/CurrentAccountsList.tsx
@@ -8,7 +8,7 @@ import {
 } from '@nofrixion/moneymoov'
 import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { redirect, useParams } from 'react-router-dom'
 
 import {
   ErrorType,
@@ -49,6 +49,7 @@ const CurrentAccountsList = ({
         apiUrl={apiUrl}
         onUnauthorized={onUnauthorized}
         onAccountClick={onAccountClick}
+        isWebComponent={isWebComponent}
       />
     </QueryClientProvider>
   )
@@ -60,11 +61,11 @@ const CurrentAccountsMain = ({
   merchantId,
   onUnauthorized,
   onAccountClick,
+  isWebComponent,
 }: CurrentAccountsListProps) => {
   const [isConnectingToBank, setIsConnectingToBank] = useState(false)
   const [banks, setBanks] = useState<BankSettings[] | undefined>(undefined)
   const { userSettings, updateUserSettings } = useUserSettings()
-  const navigate = useNavigate()
 
   const { data: accounts, isLoading: isAccountsLoading } = useAccounts(
     { connectedAccounts: true, merchantId: merchantId },
@@ -117,12 +118,12 @@ const CurrentAccountsMain = ({
   }, [])
 
   useEffect(() => {
-    if (bankId) {
+    if (isWebComponent && bankId) {
       const bank = banks?.find((bank) => bank.bankID === bankId)
 
       if (bank) {
         makeToast('success', `Your ${bank.bankName} connection is ready!`)
-        navigate(getRoute('/home/current-accounts'))
+        redirect(getRoute('/home/current-accounts'))
       }
     }
   }, [bankId, banks])
@@ -237,6 +238,8 @@ const CurrentAccountsMain = ({
           onRenewConnection={handleOnRenewConnection}
           isConnectingToBank={isConnectingToBank}
           onRevokeConnection={handleOnRevokeConnection}
+          // Disable connected accounts if it's a web component
+          areConnectedAccountsEnabled={!isWebComponent}
         />
       )}
     </>

--- a/packages/components/src/components/functional/CurrentAccountsList/CurrentAccountsList.tsx
+++ b/packages/components/src/components/functional/CurrentAccountsList/CurrentAccountsList.tsx
@@ -6,7 +6,7 @@ import {
   useBanks,
   useDeleteConnectedAccount,
 } from '@nofrixion/moneymoov'
-import { QueryClientProvider, useQueryClient } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
@@ -20,12 +20,15 @@ import CurrentAcountsList from '../../ui/Account/CurrentAccountsList/CurrentAcou
 import { Loader } from '../../ui/Loader/Loader'
 import { makeToast } from '../../ui/Toast/Toast'
 
+const queryClient = new QueryClient()
+
 export interface CurrentAccountsListProps {
   merchantId: string
   apiUrl?: string // Example: "https://api.nofrixion.com/api/v1"
   token?: string // Example: "eyJhbGciOiJIUz..."
   onUnauthorized?: () => void
   onAccountClick?: (account: Account) => void
+  isWebComponent?: boolean
 }
 
 const CurrentAccountsList = ({
@@ -34,10 +37,12 @@ const CurrentAccountsList = ({
   merchantId,
   onUnauthorized,
   onAccountClick,
+  isWebComponent,
 }: CurrentAccountsListProps) => {
-  const queryClient = useQueryClient()
+  const queryClientToUse = isWebComponent ? queryClient : useQueryClient()
+
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClientToUse}>
       <CurrentAccountsMain
         token={token}
         merchantId={merchantId}

--- a/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -15,7 +15,7 @@ import {
   useVoid,
 } from '@nofrixion/moneymoov'
 import * as Tabs from '@radix-ui/react-tabs'
-import { QueryClientProvider, useQueryClient } from '@tanstack/react-query'
+import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query'
 import { add, endOfDay, set, startOfDay } from 'date-fns'
 import { useEffect, useState } from 'react'
 
@@ -46,11 +46,14 @@ import { FilterableTag } from '../../ui/TagFilter/TagFilter'
 import { makeToast } from '../../ui/Toast/Toast'
 import PaymentRequestDetailsModal from '../PaymentRequestDetailsModal/PaymentRequestDetailsModal'
 
+const queryClient = new QueryClient()
+
 export interface PaymentRequestDashboardProps {
   token?: string // Example: "eyJhbGciOiJIUz..."
   apiUrl?: string // Example: "https://api.nofrixion.com/api/v1"
   merchantId: string
   onUnauthorized: () => void
+  isWebComponent?: boolean
 }
 
 const PaymentRequestDashboard = ({
@@ -58,10 +61,11 @@ const PaymentRequestDashboard = ({
   apiUrl = 'https://api.nofrixion.com/api/v1',
   merchantId,
   onUnauthorized,
+  isWebComponent,
 }: PaymentRequestDashboardProps) => {
-  const queryClient = useQueryClient()
+  const queryClientToUse = isWebComponent ? queryClient : useQueryClient()
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClientToUse}>
       <PaymentRequestDashboardMain
         token={token}
         merchantId={merchantId}

--- a/packages/components/src/components/ui/Account/CurrentAccountsList/CurrentAcountsList.tsx
+++ b/packages/components/src/components/ui/Account/CurrentAccountsList/CurrentAcountsList.tsx
@@ -21,6 +21,7 @@ export interface CurrentAccountsListProps {
   onRevokeConnection?: (account: Account, revokeOnlyThisAccount: boolean) => void
   banks?: BankSettings[]
   isConnectingToBank: boolean
+  areConnectedAccountsEnabled?: boolean
 }
 
 const CurrentAcountsList = ({
@@ -33,6 +34,7 @@ const CurrentAcountsList = ({
   onRevokeConnection,
   banks,
   isConnectingToBank,
+  areConnectedAccountsEnabled = true,
 }: CurrentAccountsListProps) => {
   const { userSettings } = useUserSettings()
   const [isConnectBankModalOpen, setIsConnectBankModalOpen] = useState(false)
@@ -91,16 +93,18 @@ const CurrentAcountsList = ({
     <div className="font-inter bg-main-grey text-default-text h-full">
       <div className="flex">
         <CurrentAccountsHeader onCreatePaymentAccount={onCreatePaymentAccount} />
-        {userSettings?.connectMaybeLater && externalAccounts?.length === 0 && (
-          <Button
-            variant={'secondary'}
-            className="h-fit w-fit ml-auto"
-            onClick={handleOnConnectClicked}
-          >
-            <Icon name="bank/16" className="mr-1 stroke-[#454D54]" />
-            Connect external account
-          </Button>
-        )}
+        {areConnectedAccountsEnabled &&
+          userSettings?.connectMaybeLater &&
+          externalAccounts?.length === 0 && (
+            <Button
+              variant={'secondary'}
+              className="h-fit w-fit ml-auto"
+              onClick={handleOnConnectClicked}
+            >
+              <Icon name="bank/16" className="mr-1 stroke-[#454D54]" />
+              Connect external account
+            </Button>
+          )}
       </div>
       {internalAccounts && (
         <div className="flex-row mb-8 md:mb-[68px]">
@@ -119,7 +123,7 @@ const CurrentAcountsList = ({
       )}
 
       {/* External accounts list */}
-      {externalAccounts && externalAccounts.length > 0 && (
+      {areConnectedAccountsEnabled && externalAccounts && externalAccounts.length > 0 && (
         <div>
           <div className="flex ml-3 mb-16 items-center">
             <span className="leading-8 font-medium text-2xl md:text-[1.75rem]">
@@ -155,35 +159,41 @@ const CurrentAcountsList = ({
         </div>
       )}
 
-      {!userSettings?.connectMaybeLater && externalAccounts?.length === 0 && (
-        <ExternalAccountConnectCard
-          onConnectClicked={handleOnConnectClicked}
-          onMaybeLater={onMaybeLater}
-          disabled={externalAccountConnectDisabled}
-        />
+      {areConnectedAccountsEnabled &&
+        !userSettings?.connectMaybeLater &&
+        externalAccounts?.length === 0 && (
+          <ExternalAccountConnectCard
+            onConnectClicked={handleOnConnectClicked}
+            onMaybeLater={onMaybeLater}
+            disabled={externalAccountConnectDisabled}
+          />
+        )}
+
+      {areConnectedAccountsEnabled && (
+        <>
+          <ConnectBankModal
+            banks={banks}
+            onApply={handleOnApply}
+            open={isConnectBankModalOpen}
+            onDismiss={handleOnDismiss}
+            isConnectingToBank={isConnectingToBank}
+          />
+
+          <RenewConnectionModal
+            onApply={handleOnRenewConnection}
+            open={isRenewConnectionModalOpen}
+            onDismiss={handleOnDismiss}
+            isConnectingToBank={isConnectingToBank}
+          />
+
+          <RevokeConnectionModal
+            account={selectedAccount}
+            onApply={handleOnRevokeConnection}
+            open={isRevokeConnectionModalOpen}
+            onDismiss={handleOnDismiss}
+          />
+        </>
       )}
-
-      <ConnectBankModal
-        banks={banks}
-        onApply={handleOnApply}
-        open={isConnectBankModalOpen}
-        onDismiss={handleOnDismiss}
-        isConnectingToBank={isConnectingToBank}
-      />
-
-      <RenewConnectionModal
-        onApply={handleOnRenewConnection}
-        open={isRenewConnectionModalOpen}
-        onDismiss={handleOnDismiss}
-        isConnectingToBank={isConnectingToBank}
-      />
-
-      <RevokeConnectionModal
-        account={selectedAccount}
-        onApply={handleOnRevokeConnection}
-        open={isRevokeConnectionModalOpen}
-        onDismiss={handleOnDismiss}
-      />
 
       <Toaster positionY="top" positionX="right" duration={3000} />
     </div>

--- a/packages/web-components/src/AccountDashboard.tsx
+++ b/packages/web-components/src/AccountDashboard.tsx
@@ -2,15 +2,25 @@ import ReactDOM from 'react-dom/client'
 import { AccountDashboard } from '@nofrixion/components'
 import r2wc from 'react-to-webcomponent'
 import React from 'react'
+import { AccountDashboardProps } from '@nofrixion/components/src/components/functional/AccountDashboard/AccountDashboard'
 
-const AccountDashboardWebComponent = r2wc(AccountDashboard, React, ReactDOM, {
-  props: {
-    token: 'string',
-    apiUrl: 'string',
-    accountId: 'string',
-    merchantId: 'string',
-    onAllCurrentAccountsClick: 'function',
+const AccountsReceivableWrapperForWebComponent: React.FC<AccountDashboardProps> = (props) => {
+  return <AccountDashboard {...props} isWebComponent={true} />
+}
+
+const AccountDashboardWebComponent = r2wc(
+  AccountsReceivableWrapperForWebComponent,
+  React,
+  ReactDOM,
+  {
+    props: {
+      token: 'string',
+      apiUrl: 'string',
+      accountId: 'string',
+      merchantId: 'string',
+      onAllCurrentAccountsClick: 'function',
+    },
   },
-})
+)
 
 customElements.define('account-dashboard', AccountDashboardWebComponent)

--- a/packages/web-components/src/AccountsReceivableDashboard.tsx
+++ b/packages/web-components/src/AccountsReceivableDashboard.tsx
@@ -2,13 +2,25 @@ import ReactDOM from 'react-dom/client'
 import { AccountsReceivable } from '@nofrixion/components'
 import r2wc from 'react-to-webcomponent'
 import React from 'react'
+import { PaymentRequestDashboardProps } from '@nofrixion/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard'
 
-const AccountsReceivableWebComponent = r2wc(AccountsReceivable, React, ReactDOM, {
-  props: {
-    token: 'string',
-    apiUrl: 'string',
-    merchantId: 'string',
+const AccountsReceivableWrapperForWebComponent: React.FC<PaymentRequestDashboardProps> = (
+  props,
+) => {
+  return <AccountsReceivable {...props} isWebComponent={true} />
+}
+
+const AccountsReceivableWebComponent = r2wc(
+  AccountsReceivableWrapperForWebComponent,
+  React,
+  ReactDOM,
+  {
+    props: {
+      token: 'string',
+      apiUrl: 'string',
+      merchantId: 'string',
+    },
   },
-})
+)
 
 customElements.define('payment-request-dashboard', AccountsReceivableWebComponent)

--- a/packages/web-components/src/CurrentAccountsList.tsx
+++ b/packages/web-components/src/CurrentAccountsList.tsx
@@ -2,14 +2,24 @@ import ReactDOM from 'react-dom/client'
 import { AccountsList } from '@nofrixion/components'
 import r2wc from 'react-to-webcomponent'
 import React from 'react'
+import { CurrentAccountsListProps } from '@nofrixion/components/src/components/functional/CurrentAccountsList/CurrentAccountsList'
 
-const CurrentAccountsListWebComponent = r2wc(AccountsList, React, ReactDOM, {
-  props: {
-    token: 'string',
-    apiUrl: 'string',
-    merchantId: 'string',
-    onAccountClick: 'function',
+const CurrentAccountsListWrapperForWebComponent: React.FC<CurrentAccountsListProps> = (props) => {
+  return <AccountsList {...props} isWebComponent={true} />
+}
+
+const CurrentAccountsListWebComponent = r2wc(
+  CurrentAccountsListWrapperForWebComponent,
+  React,
+  ReactDOM,
+  {
+    props: {
+      token: 'string',
+      apiUrl: 'string',
+      merchantId: 'string',
+      onAccountClick: 'function',
+    },
   },
-})
+)
 
 customElements.define('current-accounts-list', CurrentAccountsListWebComponent)


### PR DESCRIPTION
This commit addresses two issues related to the account list and web components in general:

1. The build was failing for all components due to the absence of the `QueryClient`, which had been accidentally deleted in a previous [commit](https://github.com/nofrixion/nofrixion.business/commit/e05b3555c25f1e7fa38a49bc08cf8cf30445b072). To resolve this, a new `QueryClient` is now created when building web components. For non-web components, the `useQueryClient()` hook is used to retrieve it.

2. The CurrentAccountList (`current-accounts-list`) component was not functioning correctly because it relied on `useNavigate`, which was primarily used for handling connected accounts. It was decided to remove Connected Accounts support for web components due to its complexity. To adapt the component, a new prop called `isWebComponent` was introduced, which is only provided when building the web component. This flag allows the web component's final built version to recognise its usage context. With this flag, any logic related to connected accounts, including the use of `useNavigate`, was removed and replaced with a `redirect` function from React Router (link to documentation: https://reactrouter.com/en/main/fetch/redirect). 

The CurrentAccountList now works as intended in MoneyMoov For Business (non-web component) and MoneyMoov Portal (as a web component).

Same component as web-component with no connected accounts, and as a React component WITH connected accounts:
![Current account list as web-component (no connected accounts)](https://github.com/nofrixion/nofrixion.business/assets/52673485/14296969-e644-45ba-843b-93780d11991d)

Video of both of them comparing (no connected accounts and with connected accounts):

https://github.com/nofrixion/nofrixion.business/assets/52673485/75c722eb-be0a-4ae1-bdb6-288157b264dd

