### PR TITLE
Update currency handling in Create/Edit payout modals

### DIFF
--- a/packages/components/src/components/ui/molecules/Select/SelectAccount/SelectAccount.tsx
+++ b/packages/components/src/components/ui/molecules/Select/SelectAccount/SelectAccount.tsx
@@ -32,28 +32,32 @@ const SelectAccount: React.FC<SelectAccountPros> = ({
   accounts,
   ...props
 }) => {
+  const account = accounts.find((x) => x.id === value)
+
   return (
     <Select defaultValue={defaultValue} value={value} onValueChange={onValueChange} {...props}>
       {
         <SelectTrigger
           className={cn('w-full md:w-[375px] py-3 rounded h-12 font-normal', className)}
+          placeholder="Select account"
         >
           <SelectValue asChild>
             <div className="w-full flex justify-between align-middle">
-              {value != undefined ? (
+              {account && (
                 <>
                   <span className="break-keep">
-                    {accounts.find((x) => x.id === value)!.accountName}
+                    {accounts.find((x) => x.id === value)?.accountName}
                   </span>
                   <span className="text-[#73888C]">
-                    {formatCurrency(accounts.find((x) => x.id === value)!.currency)}{' '}
+                    {account && formatCurrency(account.currency)}{' '}
                     <span className="tabular-nums">
-                      {formatAmount(accounts.find((x) => x.id === value)!.availableBalance)}
+                      {account && formatAmount(account.availableBalance)}
                     </span>
                   </span>
                 </>
-              ) : (
-                'Custom'
+              )}
+              {!account && (
+                <span className="font-normal text-grey-text text-sm">Select account</span>
               )}
             </div>
           </SelectValue>

--- a/packages/components/src/components/ui/molecules/Select/SelectBeneficiary/SelectBeneficiary.tsx
+++ b/packages/components/src/components/ui/molecules/Select/SelectBeneficiary/SelectBeneficiary.tsx
@@ -26,25 +26,25 @@ const SelectBeneficiary: React.FC<SelectBeneficiaryPros> = ({
   beneficiaries,
   ...props
 }) => {
+  const beneficiary = beneficiaries.find((x) => x.id === value)
+
   return (
     <Select value={value} onValueChange={onValueChange} {...props}>
       {
         <SelectTrigger className={cn('md:w-[27rem] py-3 h-12 rounded font-normal', className)}>
           <SelectValue asChild>
             <div className="w-full flex justify-between items-center">
-              {value != undefined ? (
+              {value ? (
                 value === 'addManually' ? (
                   <span className="text-grey-text text-sm">Add manually</span>
                 ) : (
                   <>
-                    <span className="break-keep">
-                      {beneficiaries.find((x) => x.id === value)!.destination?.name}
-                    </span>
+                    <span className="break-keep">{beneficiary?.destination?.name}</span>
                     <span className="text-xs">
                       <span className="text-[#73888C] mr-2">
-                        {beneficiaries.find((x) => x.id === value)!.destination?.accountInfo}
+                        {beneficiary?.destination?.accountInfo}
                       </span>
-                      <span>{beneficiaries.find((x) => x.id === value)!.currency}</span>
+                      <span>{beneficiary?.currency}</span>
                     </span>
                   </>
                 )


### PR DESCRIPTION
This Pull Request introduces an update to the currency handling in the Create and Edit payout modals. Previously, if a user had selected both a from account and beneficiaries and then changed the currency of the payout, the selections remained unchanged, potentially leading to mismatched currency data.

With this enhancement, if the user selects a from account and/or beneficiaries and subsequently changes the currency of the payout, the fields that don't match with the currency will be automatically deselected. This change ensures that the user will only choose from accounts and beneficiaries that match the current currency of the payout, preventing any potential currency mismatch issues.

Your feedback is highly appreciated.