### PR TITLE
Implement Skeleton Loading for Account Details on Current Account Page

### DIFF
--- a/packages/components/src/components/functional/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/functional/AccountDashboard/AccountDashboard.tsx
@@ -108,7 +108,7 @@ const AccountDashboardMain = ({
     { apiUrl: apiUrl, authToken: token },
   )
 
-  const { data: accountResponse } = useAccount(
+  const { data: accountResponse, isLoading: isLoadingAccount } = useAccount(
     { merchantId: merchantId, connectedAccounts: true },
     {
       accountId,
@@ -238,6 +238,7 @@ const AccountDashboardMain = ({
       onRenewConnection={handleOnRenewConnection}
       isConnectingToBank={isConnectingToBank}
       isLoadingTransactions={isLoadingTransactions}
+      isLoadingAccount={isLoadingAccount}
     />
   )
 }

--- a/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
@@ -39,6 +39,7 @@ export interface AccountDashboardProps extends React.HTMLAttributes<HTMLDivEleme
   banks?: BankSettings[]
   isConnectingToBank: boolean
   isLoadingTransactions?: boolean
+  isLoadingAccount?: boolean
 }
 
 const AccountDashboard: React.FC<AccountDashboardProps> = ({
@@ -58,6 +59,7 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
   banks,
   isConnectingToBank,
   isLoadingTransactions,
+  isLoadingAccount,
 }) => {
   const [localAccountName, setLocalAccountName] = useState(account?.accountName ?? '')
 
@@ -127,7 +129,10 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
           )}
           <div className="text-[28px]/8 font-semibold">
             <div className="flex group items-center space-x-2">
-              {localAccountName && (
+              {isLoadingAccount && (
+                <div className="animate-pulse w-48 h-8 bg-secondary-button rounded-lg" />
+              )}
+              {!isLoadingAccount && localAccountName && (
                 <EditableContent
                   initialValue={localAccountName}
                   onChange={handleOnAccountNameChange}
@@ -135,10 +140,15 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
               )}
             </div>
             <div className="flex gap-6 mt-2">
-              {account?.identifier.type === AccountIdentifierType.IBAN &&
+              {isLoadingAccount && (
+                <div className="animate-pulse w-56 h-4 my-2 bg-secondary-button rounded-lg" />
+              )}
+
+              {!isLoadingAccount &&
+              account?.identifier.type === AccountIdentifierType.IBAN &&
               account.identifier.iban ? (
                 <DisplayAndCopy name="IBAN" value={account.identifier.iban} className="mt-0" />
-              ) : account?.identifier.type === AccountIdentifierType.SCAN ? (
+              ) : !isLoadingAccount && account?.identifier.type === AccountIdentifierType.SCAN ? (
                 <>
                   {account?.identifier.sortCode && (
                     <DisplayAndCopy name="SC" value={account?.identifier.sortCode} />
@@ -161,14 +171,25 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
           </div>
 
           <div className="flex flex-col items-end ml-auto">
-            <AccountBalance
-              availableBalance={account?.availableBalance ?? 0}
-              balance={account?.balance ?? 0}
-              currency={account?.currency ?? Currency.None}
-            />
+            {isLoadingAccount && (
+              <>
+                <div className="animate-pulse w-48 h-9 mb-2 bg-secondary-button rounded-lg" />
+                <div className="animate-pulse w-24 h-4 bg-secondary-button rounded-lg" />
+              </>
+            )}
 
-            {pendingPayments && pendingPayments.length > 0 && (
-              <PendingPayments pendingPayments={pendingPayments} className="w-[400px]" />
+            {!isLoadingAccount && account && (
+              <>
+                <AccountBalance
+                  availableBalance={account?.availableBalance ?? 0}
+                  balance={account?.balance ?? 0}
+                  currency={account?.currency ?? Currency.None}
+                />
+
+                {pendingPayments && pendingPayments.length > 0 && (
+                  <PendingPayments pendingPayments={pendingPayments} className="w-[400px]" />
+                )}
+              </>
             )}
           </div>
         </div>

--- a/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
@@ -130,7 +130,7 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
           <div className="text-[28px]/8 font-semibold">
             <div className="flex group items-center space-x-2">
               {isLoadingAccount && (
-                <div className="animate-pulse w-48 h-8 bg-secondary-button rounded-lg" />
+                <div className="animate-pulse w-48 h-4 my-2 bg-[#E0E9EB] rounded-full" />
               )}
               {!isLoadingAccount && localAccountName && (
                 <EditableContent
@@ -141,7 +141,7 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
             </div>
             <div className="flex gap-6 mt-2">
               {isLoadingAccount && (
-                <div className="animate-pulse w-56 h-4 my-2 bg-secondary-button rounded-lg" />
+                <div className="animate-pulse w-56 h-2 my-4 bg-[#E0E9EB] rounded-full" />
               )}
 
               {!isLoadingAccount &&
@@ -173,8 +173,8 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
           <div className="flex flex-col items-end ml-auto">
             {isLoadingAccount && (
               <>
-                <div className="animate-pulse w-48 h-9 mb-2 bg-secondary-button rounded-lg" />
-                <div className="animate-pulse w-24 h-4 bg-secondary-button rounded-lg" />
+                <div className="animate-pulse w-48 h-[18px] mb-[9px] bg-[#E0E9EB] rounded-full" />
+                <div className="animate-pulse w-24 h-2 my-2 bg-[#E0E9EB] rounded-full" />
               </>
             )}
 

--- a/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
+++ b/packages/components/src/components/ui/pages/AccountDashboard/AccountDashboard.tsx
@@ -141,7 +141,9 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
             </div>
             <div className="flex gap-6 mt-2">
               {isLoadingAccount && (
-                <div className="animate-pulse w-56 h-2 my-4 bg-[#E0E9EB] rounded-full" />
+                <div className="h-8 py-3">
+                  <div className="animate-pulse w-56 h-2 bg-[#E0E9EB] rounded-full" />
+                </div>
               )}
 
               {!isLoadingAccount &&
@@ -173,8 +175,8 @@ const AccountDashboard: React.FC<AccountDashboardProps> = ({
           <div className="flex flex-col items-end ml-auto">
             {isLoadingAccount && (
               <>
-                <div className="animate-pulse w-48 h-[18px] mb-[9px] bg-[#E0E9EB] rounded-full" />
-                <div className="animate-pulse w-24 h-2 my-2 bg-[#E0E9EB] rounded-full" />
+                <div className="animate-pulse w-48 h-[18px] my-2 bg-[#E0E9EB] rounded-full" />
+                <div className="animate-pulse w-24 h-2 mt-3.5 bg-[#E0E9EB] rounded-full" />
               </>
             )}
 


### PR DESCRIPTION
This PR introduces a skeleton loading feature to the Current Account page, specifically targeting the display of account name, identifier, and balance.

# Changes
- **Skeleton Loading for Account Details**: Implemented skeleton loaders for the account name, identifier, and balance sections. This provides a smoother user experience during data loading phases, replacing blank spaces with visually appealing placeholders.

Demo video:

https://github.com/nofrixion/nofrixion.business/assets/52673485/5a406ba4-663d-410e-92ee-eafa14cc49ae

