### PR TITLE
Idempotent header

### DIFF
--- a/packages/clients/src/clients/BaseApiClient.ts
+++ b/packages/clients/src/clients/BaseApiClient.ts
@@ -6,11 +6,13 @@ import { PagedResponseProps } from '../types/props'
 
 export abstract class BaseApiClient {
   authToken?: string
+  indempotent?: boolean
   debug: boolean
 
-  constructor(authToken?: string, debug?: boolean) {
+  constructor(authToken?: string, idempotent?: boolean, debug?: boolean) {
     this.authToken = authToken
     this.debug = debug ?? false
+    this.indempotent = idempotent ?? false
   }
 
   /**
@@ -145,16 +147,22 @@ export abstract class BaseApiClient {
       contentType = 'application/x-www-form-urlencoded'
     }
 
+    let headers = {
+      Authorization: `Bearer ${this.authToken}`,
+      'content-type': contentType,
+      'X-CSRF': '1',
+    }
+
+    if (this.indempotent) {
+      headers = { ...headers, ...{ 'idempotency-key': window.crypto.randomUUID() } }
+    }
+
     try {
       const { data } = await axios<TResponse>({
         method: method,
         url: url,
         data: postData,
-        headers: {
-          Authorization: `Bearer ${this.authToken}`,
-          'content-type': contentType,
-          'X-CSRF': '1',
-        },
+        headers: headers,
       })
 
       return {

--- a/packages/clients/src/clients/BaseApiClient.ts
+++ b/packages/clients/src/clients/BaseApiClient.ts
@@ -6,13 +6,13 @@ import { PagedResponseProps } from '../types/props'
 
 export abstract class BaseApiClient {
   authToken?: string
-  indempotent?: boolean
+  idempotent?: boolean
   debug: boolean
 
   constructor(authToken?: string, idempotent?: boolean, debug?: boolean) {
     this.authToken = authToken
     this.debug = debug ?? false
-    this.indempotent = idempotent ?? false
+    this.idempotent = idempotent ?? false
   }
 
   /**
@@ -153,7 +153,8 @@ export abstract class BaseApiClient {
       'X-CSRF': '1',
     }
 
-    if (this.indempotent) {
+    // Add the 'idempotency-key' header if this is an idempotent POST request
+    if (this.idempotent && method === HttpMethod.POST) {
       headers = { ...headers, ...{ 'idempotency-key': window.crypto.randomUUID() } }
     }
 

--- a/packages/clients/src/clients/PayoutClient.ts
+++ b/packages/clients/src/clients/PayoutClient.ts
@@ -25,7 +25,7 @@ export class PayoutClient extends BaseApiClient {
    * @param authToken The OAUTH token used to authenticate with the api.
    */
   constructor({ ...props }: ApiProps) {
-    super(props.authToken)
+    super(props.authToken, true)
     this.apiUrl = `${props.apiUrl}/payouts`
   }
 


### PR DESCRIPTION
1. Adds the ability to attach an `idempotency-key` header to a POST request.
2. Enabled for the `PayoutClient`