### PR TITLE
Prevent Duplicate Tags in Payment Requests

### DIFF
--- a/packages/components/src/components/ui/Tags/AddTag/AddTag.tsx
+++ b/packages/components/src/components/ui/Tags/AddTag/AddTag.tsx
@@ -54,6 +54,11 @@ const AddTag = ({ tags, availableTags, onTagAdded, onTagCreated }: TagProps) => 
       (tag) => tag.name?.toLowerCase() === tagName.toLowerCase(),
     )
 
+    // If the tag already exists, don't add it
+    if (existingTag && tags.findIndex((tag) => tag.name === existingTag.name) !== -1) {
+      return
+    }
+
     if (existingTag) {
       onTagAdded && onTagAdded(existingTag)
     } else {

--- a/packages/components/src/components/ui/Tags/AddTag/AddTag.tsx
+++ b/packages/components/src/components/ui/Tags/AddTag/AddTag.tsx
@@ -7,6 +7,7 @@ import { useOnClickOutside } from 'usehooks-ts'
 import { v4 as uuidv4 } from 'uuid'
 
 import { LocalTag } from '../../../../types/LocalTypes'
+import { makeToast } from '../../Toast/Toast'
 
 export interface TagProps {
   tags: LocalTag[]
@@ -51,11 +52,13 @@ const AddTag = ({ tags, availableTags, onTagAdded, onTagCreated }: TagProps) => 
 
   const saveTag = () => {
     const existingTag = availableTags.find(
-      (tag) => tag.name?.toLowerCase() === tagName.toLowerCase(),
+      (tag) => tag.name?.trim().toLowerCase() === tagName.trim().toLowerCase(),
     )
 
     // If the tag already exists, don't add it
     if (existingTag && tags.findIndex((tag) => tag.name === existingTag.name) !== -1) {
+      makeToast('warning', `'${tagName}' tag was already added`)
+      reset()
       return
     }
 


### PR DESCRIPTION
Previously, users could add the same tag multiple times to a single Payment Request. This update prevents the addition of duplicate tags to a Payment Request.

# Changes
- **Duplicate Tag Prevention**: Implemented a check to disallow adding a tag to a Payment Request if it already exists.