### PR TITLE
Fix Unintended Logout Counter Display on Home Screen

### DIFF
--- a/apps/business/src/App.tsx
+++ b/apps/business/src/App.tsx
@@ -2,7 +2,6 @@ import { LocalUserRoles } from '@nofrixion/components/src/types/LocalTypes'
 import { Route, Routes } from 'react-router-dom'
 
 import HomeUI from './components/HomeUI'
-import AppLogout from './lib/auth/AppLogout'
 import { AuthProvider } from './lib/auth/AuthProvider'
 import { ProtectedRoutes } from './lib/auth/ProtectedRoutes'
 import { RoleProtectedRoute } from './lib/auth/RoleProtectedRoute'
@@ -22,61 +21,57 @@ import Root from './root'
 export const App = () => {
   return (
     <AuthProvider>
-      <AppLogout>
-        <Routes>
-          <Route element={<Root />}>
-            <Route path="*" element={<NotFound />} />
-            <Route path={getRoute('/')} element={<HomeUI />} />
-            <Route element={<ProtectedRoutes />}>
-              <Route path={getRoute('/home')} element={<Layout />}>
-                <Route element={<RoleProtectedRoute />}>
-                  <Route index element={<DashboardPage />} />
-                </Route>
-                {/* Accounts payable */}
-                <Route element={<RoleProtectedRoute />}>
-                  <Route path="accounts-payable" element={<AccountPayablePage />} />
-                </Route>
-                <Route
-                  element={
-                    <RoleProtectedRoute minimumRequiredRole={LocalUserRoles.PaymentRequestor} />
-                  }
-                >
-                  <Route path="accounts-receivable" element={<AccountReceivablePage />} />
-                </Route>
-                {/* Current accounts */}
-                <Route element={<RoleProtectedRoute />}>
-                  <Route path="current-accounts" element={<CurrentAccountsPage />} />
-                </Route>
-                <Route element={<RoleProtectedRoute />}>
-                  <Route
-                    path="current-accounts/connected/:bankId"
-                    element={<CurrentAccountsPage />}
-                  />
-                </Route>
-                <Route element={<RoleProtectedRoute />}>
-                  <Route path="current-accounts/:accountId" element={<AccountDashboardPage />} />
-                </Route>
-                {/* Payouts */}
-                <Route element={<RoleProtectedRoute />}>
-                  <Route path="payouts" element={<PayoutsPage />} />
-                </Route>
-                <Route element={<RoleProtectedRoute />}>
-                  <Route path="payouts/:payoutId/:result" element={<PayoutsPage />} />
-                </Route>
-                {/* User management */}
-                <Route
-                  element={
-                    <RoleProtectedRoute minimumRequiredRole={LocalUserRoles.AdminApprover} />
-                  }
-                >
-                  <Route path="users" element={<UsersPage />} />
-                </Route>
-                <Route path="pricing" element={<PricingPage />} />
+      <Routes>
+        <Route element={<Root />}>
+          <Route path="*" element={<NotFound />} />
+          <Route path={getRoute('/')} element={<HomeUI />} />
+          <Route element={<ProtectedRoutes />}>
+            <Route path={getRoute('/home')} element={<Layout />}>
+              <Route element={<RoleProtectedRoute />}>
+                <Route index element={<DashboardPage />} />
               </Route>
+              {/* Accounts payable */}
+              <Route element={<RoleProtectedRoute />}>
+                <Route path="accounts-payable" element={<AccountPayablePage />} />
+              </Route>
+              <Route
+                element={
+                  <RoleProtectedRoute minimumRequiredRole={LocalUserRoles.PaymentRequestor} />
+                }
+              >
+                <Route path="accounts-receivable" element={<AccountReceivablePage />} />
+              </Route>
+              {/* Current accounts */}
+              <Route element={<RoleProtectedRoute />}>
+                <Route path="current-accounts" element={<CurrentAccountsPage />} />
+              </Route>
+              <Route element={<RoleProtectedRoute />}>
+                <Route
+                  path="current-accounts/connected/:bankId"
+                  element={<CurrentAccountsPage />}
+                />
+              </Route>
+              <Route element={<RoleProtectedRoute />}>
+                <Route path="current-accounts/:accountId" element={<AccountDashboardPage />} />
+              </Route>
+              {/* Payouts */}
+              <Route element={<RoleProtectedRoute />}>
+                <Route path="payouts" element={<PayoutsPage />} />
+              </Route>
+              <Route element={<RoleProtectedRoute />}>
+                <Route path="payouts/:payoutId/:result" element={<PayoutsPage />} />
+              </Route>
+              {/* User management */}
+              <Route
+                element={<RoleProtectedRoute minimumRequiredRole={LocalUserRoles.AdminApprover} />}
+              >
+                <Route path="users" element={<UsersPage />} />
+              </Route>
+              <Route path="pricing" element={<PricingPage />} />
             </Route>
           </Route>
-        </Routes>
-      </AppLogout>
+        </Route>
+      </Routes>
     </AuthProvider>
   )
 }

--- a/apps/business/src/lib/auth/ProtectedRoutes.tsx
+++ b/apps/business/src/lib/auth/ProtectedRoutes.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../../lib/auth/useAuth'
 import { useErrorsStore } from '../stores/useErrorsStore'
 import { tryParseApiError, tryParseConnectedAccountError } from '../utils/errorUtils'
 import { getRoute } from '../utils/utils'
+import AppLogout from './AppLogout'
 import { AuthContextType } from './AuthProvider'
 
 export const ProtectedRoutes = () => {
@@ -39,6 +40,10 @@ export const ProtectedRoutes = () => {
     // user is not authenticated, redirect to login page with the return url
     return <Navigate to={getRoute('/')} replace state={{ from: location }} />
   } else {
-    return <Outlet />
+    return (
+      <AppLogout>
+        <Outlet />
+      </AppLogout>
+    )
   }
 }


### PR DESCRIPTION
This PR addresses a bug where the logout counter was incorrectly appearing on the home screen. The issue has been resolved by moving the `AppLogout` component to be within `ProtectedRoutes` only.

# Changes
- **Logout Counter Display Fix**: Adjusted the placement of the `AppLogout` component, ensuring it is only active within ProtectedRoutes, thereby preventing its appearance on the home screen.
