### PR TITLE
UI changes for no payment accounts.

### DIFF
--- a/packages/components/src/components/ui/Account/CurrentAccountsList/CurrentAcountsList.tsx
+++ b/packages/components/src/components/ui/Account/CurrentAccountsList/CurrentAcountsList.tsx
@@ -105,35 +105,38 @@ const CurrentAcountsList = ({
 
   return (
     <div className="font-inter bg-main-grey text-default-text h-full">
-      <div className="flex">
-        <CurrentAccountsHeader onCreatePaymentAccount={onCreatePaymentAccount} />
-        {areConnectedAccountsEnabled &&
-          userSettings?.connectMaybeLater &&
-          externalAccounts?.length === 0 && (
-            <Button
-              variant={'secondary'}
-              className="h-fit w-fit ml-auto"
-              onClick={handleOnConnectClicked}
-            >
-              <Icon name="bank/16" className="mr-1 stroke-[#454D54]" />
-              Connect external account
-            </Button>
-          )}
-      </div>
-      {internalAccounts && (
-        <div className="flex-row mb-8 md:mb-[68px]">
-          {internalAccounts
-            .sort((a, b) => a.accountName?.localeCompare(b.accountName))
-            .map((account, index) => (
-              <AccountCard
-                key={index}
-                account={account}
-                onClick={() => {
-                  onAccountClick && onAccountClick(account)
-                }}
-              />
-            ))}
-        </div>
+      {internalAccounts && internalAccounts.length > 0 && (
+        <>
+          <div className="flex">
+            <CurrentAccountsHeader onCreatePaymentAccount={onCreatePaymentAccount} />
+            {areConnectedAccountsEnabled &&
+              userSettings?.connectMaybeLater &&
+              externalAccounts?.length === 0 && (
+                <Button
+                  variant={'secondary'}
+                  className="h-fit w-fit ml-auto"
+                  onClick={handleOnConnectClicked}
+                >
+                  <Icon name="bank/16" className="mr-1 stroke-[#454D54]" />
+                  Connect external account
+                </Button>
+              )}
+          </div>
+
+          <div className="flex-row mb-8 md:mb-[68px]">
+            {internalAccounts
+              .sort((a, b) => a.accountName?.localeCompare(b.accountName))
+              .map((account, index) => (
+                <AccountCard
+                  key={index}
+                  account={account}
+                  onClick={() => {
+                    onAccountClick && onAccountClick(account)
+                  }}
+                />
+              ))}
+          </div>
+        </>
       )}
 
       {/* External accounts list */}
@@ -178,7 +181,9 @@ const CurrentAcountsList = ({
         externalAccounts?.length === 0 && (
           <ExternalAccountConnectCard
             onConnectClicked={handleOnConnectClicked}
-            onMaybeLater={onMaybeLater}
+            onMaybeLater={
+              internalAccounts && internalAccounts.length > 0 ? onMaybeLater : undefined
+            }
             disabled={externalAccountConnectDisabled}
           />
         )}

--- a/packages/components/src/components/ui/Account/External/ExternalAccountConnectCard.tsx
+++ b/packages/components/src/components/ui/Account/External/ExternalAccountConnectCard.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../atoms'
 
 export interface ExternalAccountConnectCardProps {
   onConnectClicked: () => void
-  onMaybeLater: () => void
+  onMaybeLater?: () => void
   disabled?: boolean
 }
 
@@ -38,12 +38,14 @@ const ExternalAccountConnectCard = ({
         >
           Connect account
         </Button>
-        <div
-          className="underline hover:no-underline ml-8 my-auto cursor-pointer"
-          onClick={onMaybeLater}
-        >
-          Maybe later
-        </div>
+        {onMaybeLater && (
+          <div
+            className="underline hover:no-underline ml-8 my-auto cursor-pointer"
+            onClick={onMaybeLater}
+          >
+            Maybe later
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
Changes suggested by Pablo I when there are no payment accounts are:

1. To not show the Current Accounts title and just show the connected accounts card in case there are no payment accounts. The reasoning is that the customer having no payment accounts would obviously be using AIS services and would know that this is expected.

2. To hide the "Maybe later" link on the card as this is the only option such a customer would have.

This is hard to test for Pablo I so attaching a video.

https://github.com/nofrixion/nofrixion.business/assets/103389834/e3ce062a-6e5d-4d78-94b2-a342774e3c2c

