### PR TITLE
Implement Destination Account Selection in Create Payment Request Modal

### DIFF
--- a/packages/components/src/components/functional/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
+++ b/packages/components/src/components/functional/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
@@ -1,4 +1,5 @@
 import {
+  Account,
   ApiError,
   ApiResponse,
   BankSettings,
@@ -6,6 +7,7 @@ import {
   ClientSettingsClient,
   PartialPaymentMethods,
   PaymentRequestCreate,
+  useAccounts,
   useBanks,
   useCreatePaymentRequest,
   UserPaymentDefaults,
@@ -104,6 +106,14 @@ const CreatePaymentRequestPageMain = ({
     { apiUrl: apiUrl, authToken: token },
   )
   const [banks, setBanks] = useState<BankSettings[] | undefined>(undefined)
+
+  const [accounts, setAccounts] = useState<Account[] | undefined>(undefined)
+
+  const { data: accountsResponse } = useAccounts(
+    { merchantId: merchantId },
+    { apiUrl: apiUrl, authToken: token },
+  )
+
   const [userPaymentDefaults, setUserPaymentDefaults] = useState<UserPaymentDefaults | undefined>(
     undefined,
   )
@@ -121,6 +131,14 @@ const CreatePaymentRequestPageMain = ({
       console.warn(banksResponse.error)
     }
   }, [banksResponse])
+
+  useEffect(() => {
+    if (accountsResponse?.status === 'success') {
+      setAccounts(accountsResponse.data)
+    } else if (accountsResponse?.status === 'error') {
+      console.warn(accountsResponse.error)
+    }
+  }, [accountsResponse])
 
   useEffect(() => {
     if (userPaymentDefaultsResponse) {
@@ -176,6 +194,7 @@ const CreatePaymentRequestPageMain = ({
       shippingLastName: paymentRequest.lastName,
       notificationEmailAddresses: paymentRequest.notificationEmailAddresses,
       useHostedPaymentPage: true,
+      pispAccountID: paymentRequest.destinationAccountID,
     }
   }
 
@@ -256,6 +275,7 @@ const CreatePaymentRequestPageMain = ({
         isOpen={isOpen}
         onClose={onClose}
         banks={banks ?? []}
+        accounts={accounts ?? []}
         onConfirm={onCreatePaymentRequest}
         userPaymentDefaults={
           isUserPaymentDefaultsLoading ? defaultUserPaymentDefaults : userPaymentDefaults

--- a/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
+++ b/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
@@ -1,5 +1,6 @@
 import { Dialog, Transition } from '@headlessui/react'
 import {
+  Account,
   ApiError,
   BankSettings,
   Currency,
@@ -43,6 +44,7 @@ import PaymentMethodIcon from '../utils/PaymentMethodIcon'
 
 export interface CreatePaymentRequestPageProps {
   banks: BankSettings[]
+  accounts: Account[]
   userPaymentDefaults?: UserPaymentDefaults
   onConfirm: (data: LocalPaymentRequestCreate) => Promise<ApiError | undefined>
   isOpen: boolean
@@ -57,6 +59,7 @@ const durationAnimationWidth = 0.3
 
 const CreatePaymentRequestPage = ({
   banks,
+  accounts,
   userPaymentDefaults,
   onConfirm,
   isOpen,
@@ -67,9 +70,7 @@ const CreatePaymentRequestPage = ({
   autoSuggestions,
 }: CreatePaymentRequestPageProps) => {
   const [amount, setAmount] = useState(prefilledData?.amount.toString() ?? '')
-  const [currency, setCurrency] = useState<'EUR' | 'GBP'>(
-    (prefilledData?.currency ?? 'EUR') as 'EUR' | 'GBP',
-  )
+  const [currency, setCurrency] = useState<Currency>(prefilledData?.currency ?? Currency.EUR)
   const [productOrService, setProductOrService] = useState(prefilledData?.productOrService ?? '')
   const [description, setDescription] = useState(prefilledData?.description ?? '')
   const [firstName, setFirstName] = useState(prefilledData?.firstName ?? '')
@@ -185,7 +186,7 @@ const CreatePaymentRequestPage = ({
 
   useEffect(() => {
     setAmount(prefilledData?.amount.toString() ?? '')
-    setCurrency((prefilledData?.currency ?? 'EUR') as 'EUR' | 'GBP')
+    setCurrency(prefilledData?.currency ?? Currency.EUR)
     setProductOrService(prefilledData?.productOrService ?? '')
     setDescription(prefilledData?.description ?? '')
     setFirstName(prefilledData?.firstName ?? '')
@@ -228,7 +229,7 @@ const CreatePaymentRequestPage = ({
   }, [prefilledData])
 
   const onCurrencyChange = (currency: string) => {
-    setCurrency(currency as 'EUR' | 'GBP')
+    setCurrency(currency as Currency)
   }
 
   const onMethodsReceived = (data: LocalPaymentMethodsFormValue) => {
@@ -305,6 +306,7 @@ const CreatePaymentRequestPage = ({
         lightning: paymentMethodsFormValue.isLightningEnabled,
       },
       notificationEmailAddresses: paymentNotificationsFormValue.emailAddresses,
+      destinationAccountID: paymentMethodsFormValue.destinationAccount?.id,
     }
 
     const apiError = await onConfirm(paymentRequestToCreate)
@@ -377,7 +379,7 @@ const CreatePaymentRequestPage = ({
 
   const resetStates = () => {
     setAmount('')
-    setCurrency('EUR')
+    setCurrency(Currency.EUR)
     setProductOrService('')
     setDescription('')
     setFirstName('')
@@ -403,6 +405,9 @@ const CreatePaymentRequestPage = ({
   }
 
   const availableMethodsDetails = [
+    ...(paymentMethodsFormValue.destinationAccount != undefined
+      ? [`*${paymentMethodsFormValue.destinationAccount.name}* set up as destination account.`]
+      : []),
     ...(paymentMethodsFormValue.isBankEnabled && paymentMethodsFormValue.priorityBank
       ? [`*${paymentMethodsFormValue.priorityBank.name}* set up as priority bank.`]
       : []),
@@ -991,7 +996,7 @@ const CreatePaymentRequestPage = ({
 
           {!isUserPaymentDefaultsLoading && (
             <PaymentMethodsModal
-              currencySymbol={currency == 'GBP' ? '£' : '€'}
+              currency={currency}
               amount={amount}
               minimumCurrencyAmount={getMinimumAmountPerCurrency(currency)}
               open={isPaymentMethodsModalOpen}
@@ -1004,6 +1009,7 @@ const CreatePaymentRequestPage = ({
               onApply={onMethodsReceived}
               onDismiss={() => setIsPaymentMethodsModalOpen(false)}
               banks={banks}
+              destinationAccounts={accounts}
             />
           )}
 

--- a/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
+++ b/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
@@ -99,6 +99,7 @@ const CreatePaymentRequestPage = ({
       isWalletEnabled: true,
       isLightningEnabled: false,
       isCaptureFundsEnabled: true,
+      isDestinationAccountEnabled: false,
       isDefault: false,
     })
 
@@ -153,6 +154,7 @@ const CreatePaymentRequestPage = ({
       isCaptureFundsEnabled:
         !userPaymentDefaults?.paymentMethodsDefaults?.cardAuthorizeOnly ?? true,
       priorityBank: findBank(userPaymentDefaults?.paymentMethodsDefaults?.pispPriorityBankID),
+      isDestinationAccountEnabled: false,
       isDefault: !!userPaymentDefaults?.paymentMethodsDefaults,
     })
   }
@@ -204,6 +206,7 @@ const CreatePaymentRequestPage = ({
           ? findBank(prefilledData?.paymentMethods?.bank?.priority?.id)
           : undefined,
         isDefault: false,
+        isDestinationAccountEnabled: false,
       })
     } else {
       fillDefaultPaymentMethods()
@@ -392,6 +395,7 @@ const CreatePaymentRequestPage = ({
       isLightningEnabled: false,
       isCaptureFundsEnabled: true,
       isDefault: false,
+      isDestinationAccountEnabled: false,
     })
     setPaymentConditionsFormValue({
       allowPartialPayments: false,

--- a/packages/components/src/components/ui/CustomModal/CustomModal.tsx
+++ b/packages/components/src/components/ui/CustomModal/CustomModal.tsx
@@ -1,6 +1,6 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import { AnimatePresence, motion } from 'framer-motion'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { cn } from '../../../utils'
 import { Button, Icon } from '../../ui/atoms'
@@ -15,6 +15,7 @@ export interface CustomModalProps extends BaseModalProps {
   buttonClaseName?: string
   showSupport?: boolean
   contentClassName?: string
+  onUseAsDefaultChanged?: (isDefaultChecked: boolean) => void
 }
 
 export interface BaseModalProps {
@@ -41,6 +42,7 @@ const CustomModal = ({
   buttonClaseName = 'w-full md:w-[10.625rem] px-16 ml-auto',
   showSupport = false,
   contentClassName = 'max-w-md',
+  onUseAsDefaultChanged,
 }: CustomModalProps) => {
   const [isDefaultChecked, setIsDefaultChecked] = useState<boolean>(false)
   const [currentState, setCurrentState] = useState<CustomModalState>()
@@ -65,6 +67,12 @@ const CustomModal = ({
       setIsDefaultChecked(currentState.isDefaultChecked)
     }
   }
+
+  useEffect(() => {
+    if (onUseAsDefaultChanged) {
+      onUseAsDefaultChanged(isDefaultChecked)
+    }
+  }, [isDefaultChecked])
 
   return (
     <Dialog.Root open={open}>

--- a/packages/components/src/components/ui/EditOptionCard/EditOptionCard.tsx
+++ b/packages/components/src/components/ui/EditOptionCard/EditOptionCard.tsx
@@ -69,7 +69,7 @@ const EditOptionCard = ({
         )}
       </div>
       {!isLoading && details && details.length > 0 && (
-        <div className="flex flex-col mt-2 text-grey-text text-xs md:ml-auto">
+        <div className="flex flex-col mt-2 text-grey-text text-xs/5 md:ml-auto">
           {details?.map((detail, index) => {
             return <span key={`detail-${index}`}>{parseBoldText(detail)}</span>
           })}

--- a/packages/components/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
+++ b/packages/components/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
@@ -1,4 +1,4 @@
-import { BankSettings, PaymentMethodsDefaults } from '@nofrixion/moneymoov'
+import { Account, BankSettings, Currency, PaymentMethodsDefaults } from '@nofrixion/moneymoov'
 import { AnimatePresence } from 'framer-motion'
 import { useEffect, useState } from 'react'
 
@@ -7,6 +7,8 @@ import BitcoinIcon from '../../../../assets/icons/bitcoin-icon-unavailable.svg'
 import CardIcon from '../../../../assets/icons/card-icon.svg'
 import ApplePayIcon from '../../../../assets/icons/wallet-icon.svg'
 import { LocalPaymentMethodsFormValue } from '../../../../types/LocalTypes'
+import { cn } from '../../../../utils'
+import { formatCurrency } from '../../../../utils/uiFormaters'
 import Checkbox from '../../Checkbox/Checkbox'
 import CustomModal, { BaseModalProps } from '../../CustomModal/CustomModal'
 import Select from '../../Select/Select'
@@ -15,9 +17,10 @@ import AnimateHeightWrapper from '../../utils/AnimateHeight'
 
 export interface PaymentMethodsModalProps extends BaseModalProps {
   amount: string
-  currencySymbol: '€' | '£'
+  currency: Currency
   minimumCurrencyAmount: number
   banks: BankSettings[]
+  destinationAccounts: Account[]
   userDefaults?: PaymentMethodsDefaults
   onApply: (data: LocalPaymentMethodsFormValue) => void
   isPrefilledData: boolean
@@ -25,10 +28,11 @@ export interface PaymentMethodsModalProps extends BaseModalProps {
 
 const PaymentMethodsModal = ({
   amount,
-  currencySymbol,
+  currency,
   minimumCurrencyAmount,
   open,
   banks,
+  destinationAccounts,
   userDefaults,
   onDismiss,
   onApply,
@@ -40,6 +44,9 @@ const PaymentMethodsModal = ({
   const [isLightningEnabled, setIsLightningEnabled] = useState<boolean>(
     userDefaults?.lightning ?? false,
   )
+  const [isDestinationAccountEnabled, setIsDestinationAccountEnabled] = useState<boolean>(
+    userDefaults?.pispPriorityBank ?? false,
+  )
   const [isPriorityBankEnabled, setIsPriorityBankEnabled] = useState<boolean>(
     userDefaults?.pispPriorityBank ?? false,
   )
@@ -47,9 +54,11 @@ const PaymentMethodsModal = ({
     !userDefaults?.cardAuthorizeOnly ?? true,
   )
   const [isDefault, setIsDefault] = useState<boolean>(!isPrefilledData && !!userDefaults)
+  const [destinationAccount, setDestinationAccount] = useState<Account | undefined>()
   const [priorityBank, setPriorityBank] = useState<BankSettings | undefined>()
   const [currentState, setCurrentState] = useState<LocalPaymentMethodsFormValue>()
   const [applyEnabled, setApplyEnabled] = useState<boolean>(true)
+  const [isDefaultChecked, setIsDefaultChecked] = useState<boolean>(false)
 
   /* Error alert states */
   const [showWalletOnlyAlert, setShowWalletOnlyAlert] = useState<boolean>(false)
@@ -100,14 +109,34 @@ const PaymentMethodsModal = ({
     }
   }, [])
 
-  // When the user clicks on the Apply button, we need to send the data to the parent component
-  const onApplyClicked = (data: any) => {
-    const formData: LocalPaymentMethodsFormValue = {
+  useEffect(() => {
+    setIsDestinationAccountEnabled(false)
+    setDestinationAccount(destinationAccounts.filter((acc) => acc.currency === currency)[0])
+
+    // Send destination account new values to override the previous ones
+    // as the state is not updated yet
+    sendDataToParent({
+      destinationAccount: undefined,
+    })
+  }, [currency])
+
+  useEffect(() => {
+    if (isPriorityBankEnabled && !priorityBank) {
+      setPriorityBank(banks[0])
+    }
+  }, [isPriorityBankEnabled])
+
+  const sendDataToParent = (data?: Partial<LocalPaymentMethodsFormValue>) => {
+    const localData: LocalPaymentMethodsFormValue = {
       isBankEnabled,
       isCardEnabled,
       isWalletEnabled,
       isLightningEnabled,
       isCaptureFundsEnabled,
+      destinationAccount:
+        isDestinationAccountEnabled && destinationAccount
+          ? { id: destinationAccount.id, name: destinationAccount?.accountName }
+          : undefined,
       priorityBank:
         isPriorityBankEnabled && priorityBank
           ? {
@@ -115,20 +144,14 @@ const PaymentMethodsModal = ({
               name: priorityBank.bankName,
             }
           : undefined,
-      isDefault: data.isDefaultChecked,
+      isDefault: isDefaultChecked,
     }
 
-    if (isPriorityBankEnabled && !priorityBank) {
-      formData.priorityBank = {
-        id: banks[0].bankID,
-        name: banks[0].bankName,
-      }
-    }
+    // Merge the data from the parent with the data from the child
+    const mergedData = { ...localData, ...data }
 
-    setCurrentState(formData)
-    onApply(formData)
-
-    return formData
+    setCurrentState(mergedData)
+    onApply(mergedData)
   }
 
   const handleOnDismiss = () => {
@@ -143,6 +166,8 @@ const PaymentMethodsModal = ({
       setIsLightningEnabled(currentState.isLightningEnabled)
       setIsCaptureFundsEnabled(currentState.isCaptureFundsEnabled)
       setIsPriorityBankEnabled(currentState.isBankEnabled)
+      setIsDestinationAccountEnabled(false)
+      setDestinationAccount(undefined)
 
       if (currentState.isBankEnabled && currentState.priorityBank) {
         const bank = banks.find((bank) => bank.bankID === currentState.priorityBank?.id)
@@ -160,6 +185,8 @@ const PaymentMethodsModal = ({
       setIsLightningEnabled(userDefaults?.lightning ?? false)
       setIsCaptureFundsEnabled(!userDefaults?.cardAuthorizeOnly ?? true)
       setIsPriorityBankEnabled(userDefaults?.pispPriorityBank ?? false)
+      setIsDestinationAccountEnabled(false)
+      setDestinationAccount(undefined)
 
       if (userDefaults?.pispPriorityBank && userDefaults?.pispPriorityBankID) {
         const bank = banks.find((bank) => bank.bankID === userDefaults.pispPriorityBankID)
@@ -170,6 +197,10 @@ const PaymentMethodsModal = ({
         setIsPriorityBankEnabled(false)
       }
     }
+  }
+
+  const handleOnUseAsDefaultChanged = (isDefaultChecked: boolean) => {
+    setIsDefaultChecked(isDefaultChecked)
   }
 
   const ValidationAlert: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
@@ -185,8 +216,9 @@ const PaymentMethodsModal = ({
       title="Payment methods"
       open={open}
       onDismiss={handleOnDismiss}
-      onApply={onApplyClicked}
+      onApply={() => sendDataToParent()}
       onApplyEnabled={applyEnabled}
+      onUseAsDefaultChanged={handleOnUseAsDefaultChanged}
       buttonRowClassName={
         isWalletEnabled && !isCardEnabled && !isBankEnabled && !isLightningEnabled ? 'md:mt-6' : ''
       }
@@ -208,9 +240,64 @@ const PaymentMethodsModal = ({
           />
 
           <AnimatePresence initial={false}>
+            {isBankEnabled && destinationAccounts.length > 0 && (
+              <AnimateHeightWrapper layoutId="checkbox-destination-account">
+                <div className="pl-6 md:pl-10 pt-7">
+                  <Checkbox
+                    label="Change destination account"
+                    infoText="This will be the account where the funds will be sent to if the payment is done via bank transfer."
+                    value={isDestinationAccountEnabled}
+                    onChange={setIsDestinationAccountEnabled}
+                  />
+                </div>
+              </AnimateHeightWrapper>
+            )}
+          </AnimatePresence>
+          <AnimatePresence>
+            {isBankEnabled && isDestinationAccountEnabled && (
+              <AnimateHeightWrapper layoutId="select-destination-account">
+                <div className="pl-6 md:pl-[3.25rem] pt-4">
+                  <Select
+                    options={destinationAccounts
+                      .filter((acc) => acc.currency === currency)
+                      .map((acc) => {
+                        return {
+                          value: acc.id,
+                          label: acc.accountName,
+                        }
+                      })}
+                    selected={
+                      !destinationAccount
+                        ? {
+                            value: destinationAccounts[0].id,
+                            label: destinationAccounts[0].accountName,
+                          }
+                        : {
+                            value: destinationAccount.id,
+                            label: destinationAccount.accountName,
+                          }
+                    }
+                    onChange={(selectedOption) => {
+                      setDestinationAccount(
+                        destinationAccounts.find((acc) => acc.id === selectedOption.value) ??
+                          destinationAccounts[0],
+                      )
+                    }}
+                  />
+                </div>
+              </AnimateHeightWrapper>
+            )}
+          </AnimatePresence>
+
+          <AnimatePresence initial={false}>
             {isBankEnabled && banks.length > 0 && (
               <AnimateHeightWrapper layoutId="checkbox-priority-bank">
-                <div className="pl-6 md:pl-10 pt-7 md:pb-4">
+                <div
+                  className={cn('pl-6 md:pl-10 md:pb-4', {
+                    'pt-7': !destinationAccounts || destinationAccounts?.length === 0,
+                    'pt-6': !destinationAccounts || destinationAccounts?.length > 0,
+                  })}
+                >
                   <Checkbox
                     label="Define a priority bank"
                     infoText="Select a priority bank to set it as the default payment option for users. This streamlines the payment process by displaying the preferred bank first."
@@ -290,7 +377,7 @@ const PaymentMethodsModal = ({
           {showPispAmountAlert && (
             <AnimateHeightWrapper layout="position" layoutId="amount-pisp-alert">
               <ValidationAlert>
-                The minimum amount for bank payments is {currencySymbol}
+                The minimum amount for bank payments is {formatCurrency(currency)}
                 {formatter.format(minimumCurrencyAmount)}. You must use another payment method for
                 lower amounts.
               </ValidationAlert>

--- a/packages/components/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
+++ b/packages/components/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
@@ -275,7 +275,7 @@ const PaymentMethodsModal = ({
                 <div className="pl-6 md:pl-10 pt-7">
                   <Checkbox
                     label="Change destination account"
-                    infoText="This will be the account where the funds will be sent to if the payment is done via bank transfer."
+                    infoText="This is the account where funds will be transferred for bank payments."
                     value={isDestinationAccountEnabled}
                     onChange={setIsDestinationAccountEnabled}
                   />

--- a/packages/components/src/components/ui/Select/Select.tsx
+++ b/packages/components/src/components/ui/Select/Select.tsx
@@ -5,6 +5,7 @@ export interface SelectProps {
   options: SelectOption[]
   selected: SelectOption
   onChange: (value: SelectOption) => void
+  disabled?: boolean
 }
 
 export interface SelectOption {
@@ -12,17 +13,23 @@ export interface SelectOption {
   label: string
 }
 
-const Select: React.FC<SelectProps> = ({ options, selected: selectedOption, onChange }) => {
+const Select: React.FC<SelectProps> = ({
+  options,
+  selected: selectedOption,
+  onChange,
+  disabled,
+}) => {
   const onChangeValue = (value: SelectOption) => {
     onChange(value)
   }
   return (
     <Listbox
+      disabled={disabled}
       value={selectedOption.value}
       onChange={(value) => onChangeValue(options.find((o) => o.value === value) ?? options[0])}
     >
       <div className="relative">
-        <Listbox.Button className="relative w-full cursor-default rounded-md bg-white p-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-transparent focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-primary-green text-sm/4 px-3 py-4 border border-border-grey font-medium">
+        <Listbox.Button className="relative w-full cursor-default rounded-md bg-white p-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-transparent focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-primary-green text-sm/4 px-3 py-4 border border-border-grey font-medium disabled:bg-main-grey disabled:cursor-not-allowed">
           <span className="block truncate pr-2">{selectedOption.label}</span>
           <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2 stroke-default-text hover:stroke-control-grey">
             <svg

--- a/packages/components/src/types/LocalTypes.ts
+++ b/packages/components/src/types/LocalTypes.ts
@@ -172,6 +172,7 @@ export interface LocalPaymentRequestCreate {
   }
   tagIds?: string[]
   notificationEmailAddresses?: string
+  destinationAccountID?: string
 }
 
 export interface LocalPaymentConditionsFormValue {
@@ -186,6 +187,10 @@ export interface LocalPaymentMethodsFormValue {
   isLightningEnabled: boolean
   isCaptureFundsEnabled: boolean
   priorityBank?: {
+    id: string
+    name: string
+  }
+  destinationAccount?: {
     id: string
     name: string
   }

--- a/packages/components/src/types/LocalTypes.ts
+++ b/packages/components/src/types/LocalTypes.ts
@@ -190,6 +190,7 @@ export interface LocalPaymentMethodsFormValue {
     id: string
     name: string
   }
+  isDestinationAccountEnabled: boolean
   destinationAccount?: {
     id: string
     name: string


### PR DESCRIPTION
This PR introduces the ability to select a destination account for the Pay by Bank feature in the Create Payment Request modal, reinstating a functionality that was present in the old portal. This enhancement is crucial for customers with multiple NoFrixion accounts, allowing them to specify the account where the funds should be received.

# Changes
- **Destination Account Picker**: Added a picker in the Create Payment Request modal for selecting the destination account. This feature aligns with the currency selected for the Payment Request.
- **Currency-Matched Accounts**: The accounts displayed in the picker correspond to the currency of the Payment Request. If there's only one account for the selected currency, only that account is shown.
- **Behaviour on Currency Change**: If the currency is changed after selecting a destination account, the selection is reset.
- **UI Enhancements**: The selected destination account name is displayed in the 'Payment methods' box and underneath the settings in the 'Review' mode of the Create Payment Request modal.
- **Exclusion from Defaults**: Due to the complexity of handling different currencies and accounts, the selected destination account does not become part of the defaults even if 'Use as my default' is chosen.

Demo video demonstrating the new feature is attached.

https://github.com/nofrixion/nofrixion.business/assets/52673485/c5a1e4eb-b782-4769-a8a0-b5ae27be191b

