### PR TITLE
Standardise Spelling to 'Authorise'

### DIFF
--- a/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
+++ b/packages/components/src/components/ui/CreatePaymentRequestPage/CreatePaymentRequestPage.tsx
@@ -300,7 +300,7 @@ const CreatePaymentRequestPage = ({
         card: {
           active: paymentMethodsFormValue.isCardEnabled,
           // Capture funds should always be true when card is disabled
-          // as it's not possible to only authorize on cards if card are disabled
+          // as it's not possible to only authorise on cards if card are disabled
           captureFunds: paymentMethodsFormValue.isCardEnabled
             ? paymentMethodsFormValue.isCaptureFundsEnabled
             : true,

--- a/packages/components/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
+++ b/packages/components/src/components/ui/Modals/PaymentMethodsModal/PaymentMethodsModal.tsx
@@ -386,7 +386,7 @@ const PaymentMethodsModal = ({
                 <div className="ml-10 pt-7 md:pb-4">
                   <Checkbox
                     label="Don't capture funds on card payments"
-                    infoText="Enable this option to authorize card payments without immediately capturing the funds. This allows for manual capture or cancellation before completing the transaction."
+                    infoText="Enable this option to authorise card payments without immediately capturing the funds. This allows for manual capture or cancellation before completing the transaction."
                     value={!isCaptureFundsEnabled}
                     onChange={(value) => setIsCaptureFundsEnabled(!value)}
                   />


### PR DESCRIPTION
# Changes
- **Spelling Standardisation**: Replaced instances of “Authorize” with “Authorise” across the application.