### PR TITLE
[MOOV-2631,MOOV-2635]: Small bugfixes to PR Dashboard empty state

### DIFF
--- a/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -592,6 +592,22 @@ const PaymentRequestDashboardMain = ({
 
   const isInitialState = !isLoadingMetrics && firstMetrics !== undefined && firstMetrics?.all === 0
 
+  const getPaymentRequests = (
+    isLoadingMetrics: boolean,
+    metrics?: PaymentRequestMetrics,
+    paymentRequests?: PaymentRequest[],
+  ) => {
+    if (isLoadingMetrics && paymentRequests && paymentRequests.length === 0) {
+      return undefined
+    }
+
+    if (metrics?.all === 0) {
+      return []
+    }
+
+    return paymentRequests
+  }
+
   return (
     <div className="font-inter bg-main-grey text-default-text h-full">
       <div className="flex gap-8 justify-between items-center mb-8 md:mb-[68px] md:px-4">
@@ -686,8 +702,8 @@ const PaymentRequestDashboardMain = ({
 
       <div className="lg:bg-white lg:min-h-[18rem] lg:pt-10 lg:pb-6 lg:px-6 lg:rounded-lg">
         <PaymentRequestTable
-          paymentRequests={paymentRequests?.map((paymentRequest) =>
-            remotePaymentRequestToLocalPaymentRequest(paymentRequest),
+          paymentRequests={getPaymentRequests(isLoadingMetrics, metrics, paymentRequests)?.map(
+            (paymentRequest) => remotePaymentRequestToLocalPaymentRequest(paymentRequest),
           )}
           pageSize={pageSize}
           totalRecords={totalRecords}

--- a/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
+++ b/packages/components/src/components/functional/PaymentRequestDashboard/PaymentRequestDashboard.tsx
@@ -296,7 +296,6 @@ const PaymentRequestDashboardMain = ({
   useEffect(() => {
     if (isLoadingMetrics) {
       setMetrics(undefined)
-      setFirstMetrics(undefined)
     }
   }, [isLoadingMetrics])
 

--- a/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
+++ b/packages/components/src/components/ui/PaymentRequestTable/PaymentRequestTable.tsx
@@ -341,7 +341,7 @@ const PaymentRequestTable = ({
         paymentRequests !== undefined &&
         paymentRequests?.length === 0 &&
         !isEmpty && (
-          // If `isEmpty` is true means that there're are no payment requests at all, no matter which tab is selected
+          // If `isEmpty` is true means that there are no payment requests at all, no matter which tab is selected
           // Else,  there are no payment requests matching the filters
           <EmptyState state="nothingFound" onCreatePaymentRequest={onCreatePaymentRequest} />
         )}


### PR DESCRIPTION
- Accounts receivable dashboard loader will not wait for the payment request fetch API call if the metrics result is empty (0 on all statuses).
- Fixed initial and subsequent 'empty' states.