### PR TITLE
[MOOV-2683]: Disabled word break on the EditColumns menu

### DIFF
--- a/packages/components/src/components/ui/Checkbox/Checkbox.tsx
+++ b/packages/components/src/components/ui/Checkbox/Checkbox.tsx
@@ -38,7 +38,12 @@ const Checkbox = ({ label, description, value, infoText, onChange, disabled }: C
       </RadixCheckbox.Root>
 
       {label && (
-        <label className="cursor-pointer pl-3 pr-2 mb-0 -mt-0.5 md:mt-0" htmlFor={id}>
+        <label
+          className={cn('cursor-pointer pl-3 pr-2 mb-0 -mt-0.5 md:mt-0', {
+            'whitespace-nowrap': !description,
+          })}
+          htmlFor={id}
+        >
           {label}
 
           {description && (


### PR DESCRIPTION
Forced `whitespace-nowrap` on the `Checkbox` element when no `description` property is provided to avoid having short labels break.