### PR TITLE
Button text change when creating new payout 

### DIFF
--- a/packages/components/src/components/ui/TableScrollbar/TableScrollbar.tsx
+++ b/packages/components/src/components/ui/TableScrollbar/TableScrollbar.tsx
@@ -19,7 +19,7 @@ const TableScrollbar = forwardRef(
           <RadixScrollArea.Scrollbar
             ref={ref}
             className={classNames('flex select-none overflow-hidden touch-non', {
-              'rounded-2xl bg-[#F6F8F9] transition-colors duration-[100ms] ease-out hover:bg-[#EAF0F1] flex-col h-4':
+              'rounded-2xl bg-[#F6F8F9] transition-colors duration-100 ease-out hover:bg-[#EAF0F1] flex-col h-4':
                 !props.hideScrollbar,
             })}
             orientation="horizontal"
@@ -32,7 +32,7 @@ const TableScrollbar = forwardRef(
                   height: '16px',
                 }}
                 className={cn(
-                  'hover:border-[#EAF0F1] hover:bg-[#73808C] border-[6px] border-[#F6F8F9] bg-[#ABB2BA] rounded-lg my-auto transition-colors duration-[100ms] ease-out',
+                  'hover:border-[#EAF0F1] hover:bg-[#73808C] border-[6px] border-[#F6F8F9] bg-[#ABB2BA] rounded-lg my-auto transition-colors duration-100 ease-out',
                   { 'border-[#EAF0F1] bg-[#73808C]': isTrackHovered },
                 )}
               ></div>

--- a/packages/components/src/components/ui/organisms/SavePayoutModal/SavePayoutModal.tsx
+++ b/packages/components/src/components/ui/organisms/SavePayoutModal/SavePayoutModal.tsx
@@ -939,7 +939,9 @@ const SavePayoutModal: React.FC<SavePayoutModalProps> = ({
                       {isCreateAndApproveButtonDisabled ? (
                         <Loader className="h-6 w-6 mx-auto" />
                       ) : (
-                        <span>Save and authorise</span>
+                        <span>
+                          {selectedPayout ? 'Save and authorise' : 'Create and authorise'}
+                        </span>
                       )}
                     </Button>
                   )}


### PR DESCRIPTION
When creating a new payout, an authoriser should see "Create and authorise payout" while when editing, they should see, "Save and authorise payout".

Made a minor change to use predefined class name for duration of 100ms in table scrollbar.