### PR TITLE
New component for FOR column in payment request table.

### DIFF
--- a/packages/components/src/components/ui/For/For.stories.tsx
+++ b/packages/components/src/components/ui/For/For.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryFn } from '@storybook/react'
+
+import For from './For'
+
+export default {
+  title: 'UI/For',
+  component: For,
+  argTypes: {
+    name: { control: 'text' },
+    email: { control: 'text' },
+  },
+} as Meta<typeof For>
+
+const Template: StoryFn<typeof For> = (args) => <For {...args} />
+
+export const Primary = Template.bind({})
+Primary.args = {
+  title: 'Monthly support',
+  customerName: 'Daniel Kowalski',
+}
+
+export const NoName = Template.bind({})
+NoName.args = {
+  title: 'Monthly support',
+}
+
+export const NoTitle = Template.bind({})
+NoTitle.args = {
+  customerName: 'Daniel Kowalski',
+}
+
+export const NoTitleAndName = Template.bind({})
+NoTitleAndName.args = {}

--- a/packages/components/src/components/ui/For/For.tsx
+++ b/packages/components/src/components/ui/For/For.tsx
@@ -1,0 +1,31 @@
+import { cn } from '../../../utils'
+
+export interface ForProps {
+  title?: string
+  customerName?: string
+}
+
+const For = ({ title, customerName }: ForProps) => {
+  return (
+    <>
+      {title || customerName ? (
+        <div className="flex flex-col">
+          {title && <p className="truncate text-13px">{title}</p>}
+          {customerName && (
+            <p
+              className={cn(' truncate break-all', title ? 'text-xs text-grey-text' : 'text-13px')}
+            >
+              {customerName}
+            </p>
+          )}
+        </div>
+      ) : (
+        <div>
+          <p className="truncate text-13px">Anonymous</p>
+        </div>
+      )}
+    </>
+  )
+}
+
+export default For

--- a/packages/components/src/components/ui/For/For.tsx
+++ b/packages/components/src/components/ui/For/For.tsx
@@ -8,22 +8,19 @@ export interface ForProps {
 const For = ({ title, customerName }: ForProps) => {
   return (
     <>
-      {title || customerName ? (
-        <div className="flex flex-col">
-          {title && <p className="truncate text-13px">{title}</p>}
-          {customerName && (
-            <p
-              className={cn(' truncate break-all', title ? 'text-xs text-grey-text' : 'text-13px')}
-            >
-              {customerName}
-            </p>
+      <div className="flex flex-col">
+        <p className={cn('truncate text-13px', { 'text-disabled-text': !title })}>
+          {title ? title : 'Untitled'}
+        </p>
+        <p
+          className={cn(
+            'truncate break-all text-xs ',
+            customerName ? 'text-grey-text' : 'text-disabled-text',
           )}
-        </div>
-      ) : (
-        <div>
-          <p className="truncate text-13px">Anonymous</p>
-        </div>
-      )}
+        >
+          {customerName ? customerName : 'Anonymous'}
+        </p>
+      </div>
     </>
   )
 }

--- a/packages/components/src/components/ui/PaymentRequestRow/PaymentRequestRow.tsx
+++ b/packages/components/src/components/ui/PaymentRequestRow/PaymentRequestRow.tsx
@@ -7,8 +7,8 @@ import { Column, LocalPaymentRequest } from '../../../types/LocalTypes'
 import { cn } from '../../../utils'
 import { formatAmount } from '../../../utils/formatters'
 import { formatCurrency } from '../../../utils/uiFormaters'
-import Contact from '../Contact/Contact'
 import Created from '../Created/Created'
+import For from '../For/For'
 import { Status } from '../molecules'
 import PaymentRequestActionMenu from '../PaymentRequestActionMenu/PaymentRequestActionMenu'
 import PaymentRequestAttemptsCell from '../PaymentRequestAttemptsCell/PaymentRequestAttemptsCell'
@@ -158,7 +158,7 @@ const Row = ({
 
       {isColumnSelected(LocalPaymentRequestTableColumns.For) && (
         <td className={classNames(commonTdClasses, `text-13px custom-backdrop-blur-${id}`)}>
-          <Contact name={title} email={customerName} size="small" />
+          <For title={title} customerName={customerName} />
         </td>
       )}
 


### PR DESCRIPTION
Found an issue with Contact component which is primarily for the payment request details modal which displays the name and email of customer. This component was reused for the FOR column but it's actually different from contact. Created a separate component which covers all cases when some or the other data won't be available.

Check the storybook to go through all the cases.