### PR TITLE
[MOOV-2705]: Fixed tab decorations overlapping with menus

### DIFF
--- a/packages/components/src/components/ui/molecules/AnimatedTabs/AnimatedTabs.tsx
+++ b/packages/components/src/components/ui/molecules/AnimatedTabs/AnimatedTabs.tsx
@@ -71,16 +71,16 @@ const AnimatedTabs: React.FC<AnimatedTabsProps> = ({
                 {tab.icon && <Icon name={tab.icon} />}
                 {tab.title}
 
+                <div className={classNames(underlineClasses, 'bg-border-grey')} />
+
                 {selectedTab == tab.title ? (
                   <motion.div
                     layoutId="underline"
-                    className={classNames(underlineClasses, 'bg-primary-green z-10')}
+                    className={classNames(underlineClasses, 'bg-primary-green')}
                   />
                 ) : (
                   <div className={classNames(underlineClasses, 'bg-border-grey')} />
                 )}
-
-                <div className={classNames(underlineClasses, 'bg-border-grey')} />
               </Tabs.Trigger>
             )
           })}


### PR DESCRIPTION
On mobile, the green tab accents would overlap with any visible pop-over or drop-down element.