### PR TITLE
[MOOV-2673]: Added plus sign to email regex

### DIFF
--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -110,7 +110,7 @@ const InvoiceSchema = object({
   }, 'Destination sort code has a wrong format.')
 
 const validateEmail = (email: string) => {
-  const re = /^([a-zA-Z0-9._%-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})$/
+  const re = /^([a-zA-Z0-9._%-+]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})$/
   return re.test(email)
 }
 


### PR DESCRIPTION
Modified the email regular expression to allow plus signs before the '@' character, just like in the API.